### PR TITLE
[김윤환]w2_리뷰요청_docker daemon과 통신하는 api

### DIFF
--- a/server/src/api/Docker.js
+++ b/server/src/api/Docker.js
@@ -1,0 +1,43 @@
+const Docker = require("dockerode");
+
+class DockerApi {
+  constructor(options) {
+    this.request = new Docker({ ...options, socketPath: null });
+  }
+
+  async init() {
+    const infos = await this.request.listContainers();
+    this.containerInfos = infos.map((info) => {
+      const keys = Object.keys(info);
+      const lowerCasedObject = keys.reduce((result, key) => {
+        const next = { ...result };
+        next[key.toLowerCase()] = info[key];
+        return next;
+      }, {});
+      return lowerCasedObject;
+    });
+  }
+
+  async execById(containerId, commandString = "") {
+    const noContainer =
+      this.containerInfos.find((info) => {
+        // support compressed-hash and full-hash
+        return info.id.startsWith(containerId);
+      }) === undefined;
+    if (noContainer) {
+      return null;
+    }
+
+    const container = await this.request.getContainer(containerId);
+    const exec = await container.exec({
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Cmd: ["/bin/sh", "-c", commandString],
+    });
+    const containerStream = await exec.start();
+    return containerStream;
+  }
+}
+
+module.exports = { DockerApi };

--- a/server/test/integration/Docker.spec.js
+++ b/server/test/integration/Docker.spec.js
@@ -1,0 +1,67 @@
+const path = require("path");
+
+const resolvedPath = path.resolve(process.cwd(), "test.env");
+require("dotenv").config({
+  path: resolvedPath,
+});
+const { expect } = require("chai");
+const { DockerApi } = require("../../src/api/Docker.js");
+
+const remoteIp = process.env.REMOTE_DOCKER_IP;
+const remotePort = process.env.REMOTE_DOCKER_PORT;
+
+const connectOptions = {
+  right: {
+    host: remoteIp,
+    port: remotePort,
+    version: "v1.40",
+  },
+  wrongPort: {
+    host: remoteIp,
+    port: 8000,
+    version: "v1.40",
+  },
+  noVersion: {
+    host: remoteIp,
+    port: remotePort,
+  },
+};
+
+const testcases = {
+  exec: {
+    options: connectOptions.right,
+    id: "d5d08093284f",
+    cmd: "echo 'hello'",
+    answer: "hello",
+  },
+};
+
+const streamResolver = (stream) => {
+  return new Promise((resolve, reject) => {
+    let result = "";
+    stream.on("data", (chunk) => {
+      // https://github.com/moby/moby/issues/7375#issuecomment-51462963
+      // docker special character prefix
+      result = chunk.slice(8).toString();
+    });
+
+    stream.on("end", () => {
+      // delete \n
+      resolve(result.slice(0, -1));
+    });
+  });
+};
+
+describe("DockerApi", () => {
+  it("container에 not-pending 형식의 명령어를 수행할 수 있다", async () => {
+    const testcase = testcases.exec;
+    const dockerClient = new DockerApi(testcase.options);
+    await dockerClient.init();
+
+    const stream = await dockerClient.execById(testcase.id, testcase.cmd);
+
+    const result = await streamResolver(stream);
+
+    expect(result).to.be.equal(testcase.answer);
+  });
+});


### PR DESCRIPTION
### 개발 상황

DockerApi는 다음과 같은 기능을 수행합니다.
1. docker daemon에게 docker engine api에 해당하는 rest api를 날릴 수 있도록 연결을 만듭니다. (https://docs.docker.com/engine/api/v1.40/)
2. docker container 정보들을 가져올 수 있습니다. (존재하지않는 container를 체크하기위한 용도)
3. docker container에게 쉘 명령을 실행할 수 있습니다.

### 질문

질문 1. docker daemon은 docker engine api를 요청으로 받습니다. 그리고 container list의 요청의 결과는 다음과 같습니다.

```
[
{
  "Id": "8dfafdbc3a40",
  "Names": [],
  "Image": "ubuntu:latest",
  "ImageID": "d74508fb6632491cea586a1fd7d748dfc5274cd6fdfedee309ecdcbc2bf5cb82",
  "Command": "echo 1",
  "Created": 1367854155,
  ...
},
{
...
},
...
]
```

위의 속성 이름이 대문자로 시작해서 기존에 있는 코드와 어울리지않게됩니다.

그래서 이 부분은 역시 따로 추상화시켜서 따로 분리하려는 계획을 가지고 있습니다. (괜찮은 선택일까요?)

질문 2.  그런데 docker container에게 쉘 명령을 보내기 전에 해당 컨테이너가 존재하는지 체크하는 부분이 있습니다.

```
const noContainer =
  this.containerInfos.find((info) => {
    // support compressed-hash and full-hash
    return info.id.startsWith(containerId);
   }) === undefined;
if (noContainer) {
  return null;
}
```

개인적으로는 요청보내는 비용보다 이렇게 명령마다 체크를 하는게 미래를 생각하면 더 괜찮은 방식이라고 생각하는데, 어떻게 생각하시나요?


