### PR TITLE
[박다정]w3_리뷰요청_도커 컨테이너 생성 및 이미지 빌드

### DIFF
--- a/server/src/api/docker.js
+++ b/server/src/api/docker.js
@@ -1,0 +1,156 @@
+const debug = require("debug")("boostwriter:api:Docker");
+const fs = require("fs");
+const Docker = require("dockerode");
+
+const changeToFormattedName = (name) => {
+  const startFormat = "/";
+  if (name.startsWith(startFormat)) {
+    return name;
+  }
+  return `${startFormat}${name}`;
+};
+
+class DockerApi {
+  constructor(options) {
+    const defaultOptions = {
+      version: "v1.40",
+      caPath: "~/.docker/ca.pem",
+      certPath: "~/.docker/cert.pem",
+      keyPath: "~/.docker/key.pem",
+      socketPath: null,
+    };
+    const requestOptions = {
+      ...defaultOptions,
+      ...options,
+    };
+
+    if (requestOptions.caPath) {
+      requestOptions.ca = fs.readFileSync(requestOptions.caPath);
+    }
+
+    if (requestOptions.certPath) {
+      requestOptions.cert = fs.readFileSync(requestOptions.certPath);
+    }
+
+    if (requestOptions.keyPath) {
+      requestOptions.key = fs.readFileSync(requestOptions.keyPath);
+    }
+
+    debug(`Docker Api create request with`, requestOptions);
+
+    this.request = new Docker(requestOptions);
+  }
+
+  async init() {
+    const infos = await this.request.listContainers();
+    this.containerInfos = infos.map((info) => {
+      const keys = Object.keys(info);
+      const lowerCasedObject = {};
+      keys.forEach((key) => {
+        lowerCasedObject[key.toLowerCase()] = info[key];
+      });
+      return lowerCasedObject;
+    });
+  }
+
+  async execById(containerId, commandString = "") {
+    const noContainer =
+      this.containerInfos.find((info) => {
+        // support compressed-hash and full-hash
+        return info.id.startsWith(containerId);
+      }) === undefined;
+    if (noContainer) {
+      return null;
+    }
+
+    const container = await this.request.getContainer(containerId);
+    const exec = await container.exec({
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Cmd: ["/bin/sh", "-c", commandString],
+    });
+    const containerStream = await exec.start();
+    return containerStream;
+  }
+
+  async execByName(containerName, commandString = "") {
+    const formattedName = changeToFormattedName(containerName);
+    const isUsedName = (info) => {
+      return info.names.includes(formattedName);
+    };
+    const targetInfo = this.containerInfos.find(isUsedName);
+    if (!targetInfo) {
+      return null;
+    }
+    const container = await this.request.getContainer(targetInfo.id);
+    const exec = await container.exec({
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Cmd: ["/bin/sh", "-c", commandString],
+    });
+    const containerStream = await exec.start();
+    return containerStream;
+  }
+
+  async createCustomTerminal(userTerminalInfo) {
+
+    if (!userTerminalInfo) {
+      const defaultBaseImage = "ubuntu";
+      return this.createContainer(defaultBaseImage);
+    }
+    // TODO 유저 입력 파싱
+    const defaultOptions = {
+      context: __dirname,
+      src: ["Dockerfile"],
+    }
+
+    const imageTag = {
+      t: "test"
+    }
+
+    const progressCallback = (err, data) => {
+      if (err) {
+        console.log(err);
+      }
+    }
+
+    const finishCallback = (err, data) => {
+      if (err) {
+        console.log(err);
+      }
+    }
+
+    const stream = await this.request.buildImage(defaultOptions, imageTag);
+
+    this.request.modem.followProgress(stream, progressCallback, finishCallback);
+  }
+
+  async createDefaultTerminal(baseImageName) {
+    // TOOD 초기 하드코딩 값 변경하거나 없앨 것
+    const defaultCmd = ["/bin/bash"];
+    const defaultTagName = "ubuntu-container-test";
+    let newContainerId = "";
+
+    await this.request.createContainer({
+      AttachStdin: false,
+      AttachStdout: true,
+      AttachStderr: true,
+      Image: baseImageName,
+      Cmd: defaultCmd,
+      name: defaultTagName,
+      Tty: true,
+    })
+    .then((container) => {
+      newContainerId = container.id;
+    })
+    .catch((err) => {
+      console.log(err);
+    });
+
+    return newContainerId;
+  }
+}
+
+module.exports = { DockerApi };

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,0 +1,42 @@
+const debug = require("debug")("boostwriter:app");
+const createError = require("http-errors");
+const express = require("express");
+const cookieParser = require("cookie-parser");
+const logger = require("morgan");
+
+const indexRouter = require("./routes/index");
+const usersRouter = require("./routes/users");
+const terminalRouter = require("./routes/terminal");
+const { DockerApi } = require("./api/docker");
+
+const app = express();
+
+app.set("docker", new DockerApi());
+
+app.use(logger("dev"));
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+app.use(cookieParser());
+
+app.use("/", indexRouter);
+app.use("/api/users", usersRouter);
+app.use("/api/terminal", terminalRouter);
+
+// catch 404 and forward to error handler
+app.use((req, res, next) => {
+  return next(createError(404));
+});
+
+// error handler
+app.use((err, req, res) => {
+  debug("Last Error Middleware", err);
+  // set locals, only providing error in development
+  res.locals.message = err.message;
+  res.locals.error = req.app.get("env") === "development" ? err : {};
+
+  // render the error page
+  res.status(err.status || 500);
+  res.render("error");
+});
+
+module.exports = app;

--- a/server/src/routes/terminal.js
+++ b/server/src/routes/terminal.js
@@ -1,0 +1,78 @@
+const debug = require("debug")("boostwriter:routes:terminal");
+const express = require("express");
+const { DockerApi } = require("../api/docker");
+const { StreamResolver } = require("../utils/stream-resolver");
+const { utils } = require("../utils");
+
+const { wrapAsync } = utils;
+
+const router = express.Router();
+
+const deleteDockerPrefix = (rawString) => {
+  return rawString.slice(8);
+};
+
+const deleteLineFeeding = (rawString) => {
+  if (rawString[rawString.length - 1] === "\n") {
+    return rawString.slice(0, -1);
+  }
+  return rawString;
+};
+
+const resolveDockerStream = async (stream) => {
+  const resolver = new StreamResolver(stream);
+  let rawString = await resolver.flush();
+  rawString = deleteDockerPrefix(rawString);
+  rawString = deleteLineFeeding(rawString);
+  return rawString;
+};
+
+const dockerOptions = {
+  host: process.env.REMOTE_DOCKER_IP,
+  port: process.env.REMOTE_DOCKER_PORT,
+  caPath: process.env.SSL_CA_PATH,
+  certPath: process.env.SSL_CERT_PATH,
+  keyPath: process.env.SSL_KEY_PATH,
+};
+
+const dockerClient = new DockerApi(dockerOptions);
+
+router.post(
+  "/command/not-pending",
+  wrapAsync(async (req, res) => {
+    const { containerName, cmd, options } = req.body;
+
+    await dockerClient.init();
+
+    const resultStream = await dockerClient.execByName(containerName, cmd);
+    const output = await resolveDockerStream(resultStream);
+
+    debug(
+      `containerName: ${containerName}`,
+      `command: ${cmd}`,
+      `options: ${options}`,
+      `result: ${output}`
+    );
+
+    res.status(200).send({ output });
+  })
+);
+
+router.post(
+  "/createTerminal",
+  async (req, res) => {
+    const docker = req.app.get("docker");
+    const result = await docker.createDefaultTerminal("ubuntu");
+
+    if (!result) {
+      res.status(400).json({message: "not created terminal"});
+      return;
+    }
+
+    res.status(200).json({containerId: result});
+    
+    return;
+  }
+)
+
+module.exports = router;


### PR DESCRIPTION
[터미널 요청 서버 프로세스](https://docs.google.com/presentation/d/1srP6WXoJ576zPpHJOrIL7GNFuxPQLzmmdOutRMwmzGY/edit#slide=id.p)

**프로젝트 내용**
유저(주로 개발자)가 에디터로 문서를 작성하면서 코드의 실행결과나 터미널 작업으로 결과를 알고 싶을 때 화면의 전환 없이 작성하기 위해 에디터에 터미널 UI가 있고 입력을 하면 서버에서 그 명령을 받아서 처리를 합니다.

**현재상황**
초기에는 고정된 운영체제와 단순한 환경만 지원하지만 점점 갖추어 나가면서 다양한 운영체제와 database등 많은 개발 환경을 터미널에서 지원하려고 합니다. 현재는 에디터 화면에서 기본 우분투 환경만 제공합니다.

**시나리오**
유저가 화면에서 터미널 생성을 누르면 해당 REST API를 express 서버에 요청하고 그것에 해당하는 docker api를 호출하여 docker를 관리하는 서버에 create container에 해당하는 명령어를 실행하고 결과값을 다시 받고 클라이언트에 반환합니다. 