### PR TITLE
[김윤환]w3_리뷰요청_Terminal 환경설정을 할 수 있는 뷰를 테스트

### DIFF
--- a/client/src/actions/TerminalSettingAction.js
+++ b/client/src/actions/TerminalSettingAction.js
@@ -1,0 +1,36 @@
+const TERMINAL_SETTING_ACTION = {
+  OPEN: "terminal-setting/open",
+  CLOSE: "terminal-setting/close",
+  SELECT: "terminal-setting/select",
+  UNSELECT: "terminal-setting/unselect",
+};
+
+const terminalSettingActionCreator = {
+  open() {
+    return {
+      type: TERMINAL_SETTING_ACTION.OPEN,
+    };
+  },
+
+  close() {
+    return {
+      type: TERMINAL_SETTING_ACTION.CLOSE,
+    };
+  },
+
+  select(option) {
+    return {
+      type: TERMINAL_SETTING_ACTION.SELECT,
+      option,
+    };
+  },
+
+  unselect(option) {
+    return {
+      type: TERMINAL_SETTING_ACTION.UNSELECT,
+      option,
+    };
+  },
+};
+
+export { TERMINAL_SETTING_ACTION, terminalSettingActionCreator };

--- a/client/src/components/editor/side-window/TerminalSetting.jsx
+++ b/client/src/components/editor/side-window/TerminalSetting.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import styled from "styled-components";
+
+const TERMINAL = {
+  TITLE: "환경설정",
+};
+
+const TerminalSettingWrapper = styled.div`
+  position: absolute;
+
+  top: 0;
+  right: 0;
+
+  padding: 1rem;
+  margin: 0;
+
+  width: 20rem;
+  height: 100%;
+
+  border: solid black;
+
+  background: green;
+`;
+
+const TerminalSettingTitle = styled.h1`
+  padding: 0;
+  margin: 0;
+`;
+
+const TerminalSetting = () => {
+  return (
+    <TerminalSettingWrapper>
+      <TerminalSettingTitle>{TERMINAL.TITLE}</TerminalSettingTitle>
+    </TerminalSettingWrapper>
+  );
+};
+
+export default TerminalSetting;

--- a/client/src/pages/EditorPage.jsx
+++ b/client/src/pages/EditorPage.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+import styled from "styled-components";
+import { CellStore } from "../stores/CellStore";
+import EditorComponent from "../components/editor/EditorComponent";
+import EditorHeader from "../components/editor/header/EditorHeader";
+import EditorToolbar from "../components/editor/toolbar/ToolBar";
+import EditorInput from "../components/editor/EditorInput";
+import TerminalSetting from "../components/editor/side-window/TerminalSetting";
+
+const EditorWindowLayout = styled.div`
+  position: relative;
+
+  display: flex;
+  flex-flow: column;
+
+  height: 100vh;
+`;
+
+const MarkdownWindowLayout = styled.div`
+  position: relative;
+
+  padding: 0;
+
+  height: 100%;
+
+  overflow: auto;
+`;
+
+const EditorPage = () => {
+  return (
+    <>
+      <CellStore>
+        <EditorWindowLayout>
+          <EditorHeader />
+          <EditorToolbar />
+          <MarkdownWindowLayout>
+            <EditorInput />
+            <EditorComponent />
+            <TerminalSetting />
+          </MarkdownWindowLayout>
+        </EditorWindowLayout>
+      </CellStore>
+    </>
+  );
+};
+
+export default EditorPage;

--- a/client/src/reducers/TerminalSettingReducer.js
+++ b/client/src/reducers/TerminalSettingReducer.js
@@ -1,0 +1,55 @@
+import { TERMINAL_SETTING_ACTION } from "../actions/TerminalSettingAction";
+
+const isAlreadySelected = (options, nOption) => {
+  const isSameOption = (option) => option.id === nOption.id;
+  return options.some(isSameOption);
+};
+
+const terminalReducerHandler = {
+  [TERMINAL_SETTING_ACTION.OPEN]: (state) => {
+    return {
+      ...state,
+      isTerminalSettingOpen: true,
+    };
+  },
+
+  [TERMINAL_SETTING_ACTION.CLOSE]: (state) => {
+    return {
+      ...state,
+      isTerminalSettingOpen: false,
+    };
+  },
+
+  [TERMINAL_SETTING_ACTION.SELECT]: (state, action) => {
+    const { options } = state;
+    if (isAlreadySelected(options, action.option)) {
+      return state;
+    }
+    return {
+      ...state,
+      options: [...options, action.option],
+    };
+  },
+
+  [TERMINAL_SETTING_ACTION.UNSELECT]: (state, action) => {
+    const { options } = state;
+    const isNotSameOption = (option) => option.id !== action.option.id;
+    const trimmedOptions = options.filter(isNotSameOption);
+    return {
+      ...state,
+      options: trimmedOptions,
+    };
+  },
+};
+
+const terminalSettingReducer = (state, action) => {
+  const handler = terminalReducerHandler[action.type];
+
+  if (handler === undefined) {
+    return state;
+  }
+
+  return handler(state, action);
+};
+
+export default terminalSettingReducer;

--- a/client/test/unit/TerminalSetting.spec.js
+++ b/client/test/unit/TerminalSetting.spec.js
@@ -1,0 +1,42 @@
+import {
+  TERMINAL_SETTING_ACTION,
+  terminalSettingActionCreator as tsActionCreator,
+} from "../../src/actions/TerminalSettingAction";
+import terminalSettingReducer from "../../src/reducers/TerminalSettingReducer.js";
+
+class TestStore {
+  constructor(reducer, state = {}) {
+    this.state = state;
+    this.reducer = reducer;
+  }
+
+  dispatch(action) {
+    this.state = this.reducer(this.state, action);
+    return this.state;
+  }
+};
+
+const testcases = {
+  open: [
+    {
+      init: {
+        isTerminalSettingOpen: false,
+        options: [],
+      },
+      answer: true,
+    },
+  ],
+};
+
+describe("Terminal Setting Side Window", () => {
+
+  it("open window", () => {
+    testcases.open.map((testcase) => {
+      const { init, answer } = testcase;
+      const store = new TestStore(terminalSettingReducer, init);
+      const nextState = store.dispatch(tsActionCreator.open());
+      expect(nextState.isTerminalSettingOpen).toEqual(answer);
+    });
+  });
+});
+


### PR DESCRIPTION
![Screenshot from 2019-11-22 11-11-31](https://user-images.githubusercontent.com/4661295/69392417-48815380-0d19-11ea-9f7d-ead467f8a00e.png)

위에 초록색 부분이 될 모습은 아래와 같습니다.

![환경설정창](https://user-images.githubusercontent.com/4661295/69392544-a9a92700-0d19-11ea-91d6-06bd04abb71d.png)

위 환경설정창에 사용자가 옵션을 선택할 수 있습니다. 

그리고 선택한 옵션을 저장해두어서 창을 열고 닫아도 이전에 선택한 옵션을 그대로 유지하게 만들 계획입니다.

그리고 다른 버튼을 통해서 뷰를 열고 닫을 수 있게하기 위해서 이를 위한 action과 reducer를 만들어서 jest를 통해 테스트 중에 있습니다.

### 질문

ui를 랜더링하게만드는 데이터를 테스트하는게 더 의미가 있다 생각되어 reducer를 테스트하는 방향으로 진행하고 있습니다. 그런데 enzyme이나 react-testing-library가 react hooks를 사용한 함수 컴포넌트에서는 Context나 내부 state를 가져오지를 못하는것으로 알고있습니다. 이에 대해서 현업에서 혹은 개인적으로 테스트하는 방법이 있는지 궁금합니다.
