### PR TITLE
[윤준환]w3_리뷰요청_마크다운 스타일

### DIFF
--- a/client/components/editor/EditorInput.jsx
+++ b/client/components/editor/EditorInput.jsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+
+import MARKDOWN_REGEXP from "../../utils/index";
+
+/**
+ * @todo keys 파싱 부분 정규표현식으로 변경
+ */
+const stateAttr = {
+  [MARKDOWN_REGEXP.H1]: { type: "h1", placeholder: "Heading 1" },
+  "##": { type: "h2", placeholder: "Heading 2" },
+  "###": { type: "h3", placeholder: "Heading 3" },
+  "####": { type: "h4", placeholder: "Heading 4" },
+  "#####": { type: "h5", placeholder: "Heading 5" },
+  "######": { type: "h6", placeholder: "Heading 6" },
+
+  "-": { type: "ul", placeholder: "Unordered List" },
+  "*": { type: "ul", placeholder: "Unordered List" },
+  "+": { type: "ul", placeholder: "Unordered List" },
+
+  "1.": { type: "ol", placeholder: "Ordered List" },
+
+  ">": { type: "blockquote", placeholder: "Quote" }
+};
+
+/**
+ * 마크다운 스타일 버전 2
+ * 각 마크다운 문법에 적용되는 태그 사용 후 각 contentEditable 속성 사용
+ *
+ * @pros overflow시 자동으로 줄바꿈 적용, 각 default 속성을 찾아 디자인 작업 생략 가능
+ * @cons div 혹은 p 등 태그 설정 기준 모호, placeholder 적용을 가상 클래스 및 가상 엘리먼트로 구현 필요(복잡성 증가)
+ */
+const MarkdownWrapper = styled.div`
+  border: none;
+
+  &:empty {
+    &::before {
+      content: attr(placeholder);
+      color: silver;
+    }
+  }
+  &:focus {
+    outline: none;
+  }
+  &:hover {
+    cursor: text;
+  }
+
+  border-left: ${props => (props.isQuote ? "0.25rem solid silver" : null)};
+  padding-left: ${props => (props.isQuote ? "0.5rem" : null)};
+`;
+
+const EditorInput = () => {
+  const [state, setState] = useState({
+    value: "",
+    type: "",
+    placeholder: ""
+  });
+
+  const onInput = ev => {
+    setState({ ...state, value: ev.target.textContent });
+  };
+
+  const onKeyPress = ev => {
+    const { key } = ev;
+
+    switch (key) {
+      case " ":
+        if (!state.type) setState({ ...state, ...stateAttr[state.value] });
+        break;
+      case "Enter":
+        break;
+    }
+  };
+
+  const isList = state.type === "ul" || state.type === "ol";
+  const isQuote = state.type === "blockquote";
+
+  let renderTarget = (
+    <MarkdownWrapper
+      as={state.type}
+      isQuote={isQuote}
+      placeholder={state.placeholder}
+      contentEditable={true}
+      onInput={onInput}
+      onKeyPress={onKeyPress}
+    />
+  );
+
+  if (isList) {
+    renderTarget = (
+      <MarkdownWrapper as={state.type}>
+        <MarkdownWrapper
+          as="li"
+          placeholder={state.placeholder}
+          contentEditable={true}
+          onInput={onInput}
+          onKeyPress={onKeyPress}
+        />
+      </MarkdownWrapper>
+    );
+  }
+
+  return renderTarget;
+};
+
+export default EditorInput;

--- a/client/components/editor/EditorInputV1.jsx
+++ b/client/components/editor/EditorInputV1.jsx
@@ -1,0 +1,71 @@
+/**
+ * 마크다운 스타일 버전 1
+ * input(textarea) 태그 사용 후 각 마크다운 문법에 맞는 스타일링
+ *
+ * @pros placeholder 속성, 사용자의 입력을 받는 부분으로 태그 의미 적합
+ * @cons input 태그의 경우 overflow시 줄바꿈이 되지 않음
+ *       textarea 태그의 경우 크롬에서 scroll이 아닌 visible로 값을 설정해도 스크롤로 적용
+ *       scrollHeight와 함께 height를 적용하며 구현하는 방법 필요(복잡성 증가)
+ */
+const HEADING_ATTRIBUTE = {
+  diplay: "block",
+  fontWeight: "bold"
+};
+
+const MARKDOWN_ATTRIBUTE = {
+  [MARKDOWN_TYPE.DEFAULT]: {
+    placeholder: "",
+    fontSize: "medium",
+    marginTopBottom: "0"
+  },
+
+  [MARKDOWN_TYPE.H1]: {
+    ...HEADING_ATTRIBUTE,
+    placeholder: "Heading 1",
+    fontSize: "2em",
+    marginTopBottom: "0.67em"
+  },
+  [MARKDOWN_TYPE.H2]: {
+    ...HEADING_ATTRIBUTE,
+    placeholder: "Heading 2",
+    fontSize: "1.5em",
+    marginTopBottom: "0.83em"
+  },
+  [MARKDOWN_TYPE.H3]: {
+    ...HEADING_ATTRIBUTE,
+    placeholder: "Heading 3",
+    fontSize: "1.17em",
+    marginTopBottom: "1em"
+  },
+  [MARKDOWN_TYPE.H4]: {
+    ...HEADING_ATTRIBUTE,
+    placeholder: "Heading 4",
+    fontSize: "1em",
+    marginTopBottom: "1.33em"
+  },
+  [MARKDOWN_TYPE.H5]: {
+    ...HEADING_ATTRIBUTE,
+    placeholder: "Heading 5",
+    fontSize: ".83em",
+    marginTopBottom: "1.67em"
+  },
+  [MARKDOWN_TYPE.H6]: {
+    ...HEADING_ATTRIBUTE,
+    placeholder: "Heading 6",
+    fontSize: ".67em",
+    marginTopBottom: "2.33em"
+  }
+};
+
+const Input = styled.input`
+  display: block;
+  font-weight: bold;
+  width: 100%;
+  border: transparent;
+  outline: transparent;
+  display: ${props => MARKDOWN_ATTRIBUTE[props.type].display};
+  font-weight: ${props => MARKDOWN_ATTRIBUTE[props.type].fontWeight};
+  font-size: ${props => MARKDOWN_ATTRIBUTE[props.type].fontSize};
+  margin-top: ${props => MARKDOWN_ATTRIBUTE[props.type].marginTopBottom};
+  margin-bottom: ${props => MARKDOWN_ATTRIBUTE[props.type].marginTopBottom}};
+`;


### PR DESCRIPTION
안녕하세요.
부스트캠프 리뷰요청자 윤준환입니다.

styled-components를 활용해 마크다운 문법에 따라 스타일을 하고 있습니다.
문법에 따라 WYSIWYG으로 적용 여부를 placeholder를 통해 제공합니다.

사용자의 입력을 받는 부분으로 의미에 적합한 input 태그에 스타일을 적용하는 방법을 고려했으나,
width 이상의 입력을 했을 때 overflow가 줄바꿈으로 적용되지 않는 문제점이 있었습니다.

textarea를 사용하고 height를 계산하는 방법으로 구현 중, html5에서 contentEditable 속성을 통해 Input 및 textarea 외에도 입력을 받을 수 있는 것을 알았습니다.

위와 같은 구현에서 input 혹은 textarea를 활용할 수 있는 팁 혹은 contentEditable 속성 적용이 적합한지에 대한 의견을 받을 수 있다면 부탁드립니다.
(textarea의 경우 value, 이외 태그는 textContent 속성을 통해 입력값을 참조해야 하여 contentEditable 속성 적용 등 통일성을 위해 현재 기본 default 입력창의 경우 div 태그인 상태인데,  태그를 어떤 것으로 선택해야 할지 조언 부탁드립니다.

또한, 리스트 스타일의 경우 ul 및 ol 태그 하위 요소로 li 태그가 들어가야 하는데,  리스트 여부에 따른 조건부 렌더링을 어떤 방법으로 해야 깔끔한 코드를 작성할 수 있는지 조언 부탁드립니다.

지난 주차 섬세한 리뷰에 많은 도움이 되었습니다.
이번 주차 또한 리뷰에 시간 할애해주시는 점 미리 감사하다는 말씀 드립니다.
(지난 주차 다른 팀원으로 mention(@)되었는데 저는 RBJH입니다! :) )