### PR TITLE
문서 제목 컴포넌트 버그 수정

### DIFF
--- a/client/src/components/editor/header/DocumentTitle.jsx
+++ b/client/src/components/editor/header/DocumentTitle.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
+import HandlerManager from "../../../utils/HandlerManager";
+import EVENT_TYPE from "../../../enums/EVENT_TYPE";
 
 const DocumentTitleInput = styled.div`
   display: inline-block;
@@ -33,11 +35,18 @@ const DocumentTitle = (props) => {
     setState(documentTitle);
   };
 
+  const onClickHandler = (e) => {};
+
+  HandlerManager.initHandler();
+  HandlerManager.setHandler(EVENT_TYPE.ENTER, onClickHandler);
+  HandlerManager.setWindowKeydownEvent();
+
   return (
     <DocumentTitleInput
       contentEditable={props.contentEditable}
       onInput={onInputHandler}
       data-text={props.defaultText}
+      onClick={onClickHandler}
     />
   );
 };


### PR DESCRIPTION
문서제목을 입력하던 도중에 엔터를 누르면
cell component커서의 위치로 문서제목이 복사되는
버그를 수정함