### PR TITLE
[김윤환]w4_리뷰요청_Terminal React component

### DIFF
--- a/client/src/components/editor/cells/Terminal/index.jsx
+++ b/client/src/components/editor/cells/Terminal/index.jsx
@@ -1,0 +1,302 @@
+import React, {
+  useImperativeHandle,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+} from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import createDebug from "debug";
+
+import { EVENT_TYPE, THEME } from "../../../../enums";
+import { utils, handlerManager, request } from "../../../../utils";
+import { terminalActionCreator as action } from "../../../../actions/TerminalAction";
+import {
+  TerminalStore,
+  TerminalContext,
+  TerminalDispatchContext,
+} from "../../../../stores/TerminalStore";
+import { setGenerator } from "../CellGenerator";
+
+setGenerator("terminal", (uuid) => <TerminalCell cellUuid={uuid} />);
+
+const debug = createDebug("boost:terminal-cell");
+
+const { splice } = utils;
+
+const ReplInputWrapper = styled.div`
+  display: flex;
+
+  height: 100%;
+
+  padding: 15px;
+  margin: 10px;
+
+  background-color: ${THEME.VS_CODE.INNER_BOX};
+`;
+
+const ReplOutputWrapper = styled.div`
+  height: 100%;
+
+  padding: 15px;
+  margin: 10px;
+
+  background: ${THEME.VS_CODE.INNER_BOX};
+
+  white-space: pre-wrap;
+`;
+
+const TerminalWrapper = styled.div`
+  position: relative;
+
+  display: flex;
+  flex-flow: column;
+
+  background: ${THEME.VS_CODE.SIDE_MENU};
+  width: 100%;
+`;
+
+const ReplPrompt = styled.div`
+  border-right: 5px solid #00fe3d;
+  padding-right: 10px;
+  width: 5rem;
+`;
+
+const ReplInput = styled.div.attrs((props) => ({
+  spellCheck: false,
+  contentEditable: props.isEditorable || false,
+}))`
+  flex-grow: 99;
+  margin-left: 20px;
+
+  &:focus {
+    outline: none;
+    border: none;
+  }
+`;
+
+const ReplInputComponent = React.forwardRef(
+  ({ text, isEditorable, inputHandler }, ref) => {
+    const inputRef = useRef();
+    const prompt = "User $";
+
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        if (!inputRef || !inputRef.current) {
+          return;
+        }
+        inputRef.current.focus();
+      },
+    }));
+
+    return (
+      <ReplInputWrapper>
+        <ReplPrompt>{prompt}</ReplPrompt>
+        <ReplInput
+          ref={inputRef}
+          onInput={inputHandler}
+          isEditorable={isEditorable}
+        >
+          {text}
+        </ReplInput>
+      </ReplInputWrapper>
+    );
+  }
+);
+
+ReplInputWrapper.propTypes = {
+  text: PropTypes.string,
+};
+
+ReplInputWrapper.defaultProps = {
+  text: "",
+};
+
+const ReplOutputComponent = ({ text, isLoading }) => {
+  const outputText = text === "" ? "No output" : text;
+  return <ReplOutputWrapper>{outputText}</ReplOutputWrapper>;
+};
+
+ReplOutputWrapper.propTypes = {
+  isLoading: PropTypes.bool,
+  text: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+};
+
+const addHandlersToManager = (focusHandlers) => {
+  handlerManager.initHandler();
+  handlerManager.setHandler(EVENT_TYPE.ENTER, (e) =>
+    focusHandlers[EVENT_TYPE.ENTER](e)
+  );
+  handlerManager.setHandler(EVENT_TYPE.ARROW_UP, (e) =>
+    focusHandlers[EVENT_TYPE.ARROW_UP](e)
+  );
+  handlerManager.setHandler(EVENT_TYPE.ARROW_DOWN, (e) =>
+    focusHandlers[EVENT_TYPE.ARROW_DOWN](e)
+  );
+  handlerManager.setWindowKeydownEvent();
+};
+
+const ReplCell = ({
+  cellIndex,
+  inputText,
+  outputText,
+  isActive,
+  isLoading,
+}) => {
+  const dispatch = useContext(TerminalDispatchContext);
+
+  useEffect(() => {
+    const updateOutputComponent = async () => {
+      const containerName = "zen_liskov";
+      const command = inputText;
+
+      const { data, status } = await request.exec(containerName, command);
+
+      debug("shell command response with", status, data);
+
+      if (status === 200) {
+        const { output } = data;
+        dispatch(action.updateOutputText(cellIndex, output));
+      }
+    };
+
+    const isStartFetching = !isActive && isLoading;
+    if (isStartFetching) {
+      updateOutputComponent();
+    }
+  }, [isLoading]);
+
+  return (
+    <>
+      <ReplInputComponent text={inputText} isActive={isActive} />
+      <ReplOutputComponent text={outputText} isLoading={isLoading} />
+    </>
+  );
+};
+
+ReplCell.propTypes = {
+  cellIndex: PropTypes.number.isRequired,
+  inputText: PropTypes.string,
+  outputText: PropTypes.string,
+  isActive: PropTypes.bool,
+  isLoading: PropTypes.bool,
+};
+
+ReplCell.defaultProps = {
+  inputText: "default inputText",
+  outputText: "default outputText",
+  isActive: true,
+  isLoading: false,
+};
+
+const MovableReplCell = ({ inputHandler }) => {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const isComponentFocus = ref && ref.current;
+    if (isComponentFocus) {
+      ref.current.focus();
+    }
+  }, [ref]);
+
+  return (
+    <ReplInputComponent ref={ref} inputHandler={inputHandler} isEditorable />
+  );
+};
+
+MovableReplCell.propTypes = {
+  inputHandler: PropTypes.func.isRequired,
+};
+
+const ReplContainer = () => {
+  const [movable, setMovable] = useState(null);
+  const dispatchAsync = useContext(TerminalDispatchContext);
+  const { terminalState } = useContext(TerminalContext);
+  const {
+    focusIndex,
+    replCount,
+    inputTexts,
+    outputTexts,
+    isActives,
+    isLoadings,
+  } = terminalState;
+
+  const focusHandlers = {
+    [EVENT_TYPE.ENTER]: (e) => {
+      e.preventDefault();
+      dispatchAsync(action.createNewRepl());
+    },
+
+    [EVENT_TYPE.ARROW_UP]: (e) => {
+      e.preventDefault();
+      const isFocusInMiddle = focusIndex >= 0 && focusIndex <= replCount;
+      if (isFocusInMiddle) {
+        debug("Focus Up In Terminal");
+        dispatchAsync(action.focusChange(-1));
+      } else if (focusIndex === replCount) {
+        debug("Focus Up Max");
+      }
+    },
+
+    [EVENT_TYPE.ARROW_DOWN]: (e) => {
+      e.preventDefault();
+      if (focusIndex === replCount) {
+        debug("Focus Down Max");
+      } else if (focusIndex >= 0 && focusIndex < replCount) {
+        debug("Focus Down In Terminal");
+        dispatchAsync(action.focusChange(+1));
+      }
+    },
+  };
+
+  const inputHandler = (e) => {
+    const text = e.target.textContent;
+    dispatchAsync(action.changeCurrentText(text));
+  };
+
+  useEffect(() => {
+    addHandlersToManager(focusHandlers);
+    setMovable(<MovableReplCell inputHandler={inputHandler} />);
+  }, []);
+
+  const renderRepls = () => {
+    const repls = inputTexts.map((_, index) => {
+      const componentKey = `repl/${index}`;
+      return (
+        <ReplCell
+          key={componentKey}
+          cellIndex={index}
+          inputText={inputTexts[index]}
+          outputText={outputTexts[index]}
+          isActive={isActives[index]}
+          isLoading={isLoadings[index]}
+        />
+      );
+    });
+
+    const isFirstRender = movable && replCount === 0;
+    if (isFirstRender) {
+      return movable;
+    }
+    return splice.addBefore(repls, focusIndex, movable);
+  };
+
+  return <>{renderRepls()}</>;
+};
+
+const TerminalCell = ({ cellUuid }) => {
+  return (
+    <TerminalStore>
+      <TerminalWrapper>
+        <ReplContainer />
+      </TerminalWrapper>
+    </TerminalStore>
+  );
+};
+
+TerminalCell.propTypes = {
+  cellUuid: PropTypes.string.isRequired,
+};
+
+export default TerminalCell;

--- a/client/src/reducers/TerminalReducer.js
+++ b/client/src/reducers/TerminalReducer.js
@@ -1,0 +1,157 @@
+import { TERMINAL_ACTION } from "../actions/TerminalAction";
+import { utils } from "../utils";
+
+const { deepCopy, splice } = utils;
+
+const appendNewRepl = (prevState) => {
+  const {
+    inputTexts,
+    isActives,
+    outputTexts,
+    isLoadings,
+    currentText,
+  } = prevState;
+
+  const nextInputs = [...inputTexts, currentText];
+  const nextActives = [...isActives, false];
+
+  const nextOutputs = [...outputTexts, ""];
+  const nextLoadings = [...isLoadings, true];
+
+  return {
+    inputTexts: nextInputs,
+    isActives: nextActives,
+    outputTexts: nextOutputs,
+    isLoadings: nextLoadings,
+  };
+};
+
+const updateRepl = (prevState) => {
+  const {
+    inputTexts,
+    isActives,
+    outputTexts,
+    isLoadings,
+    focusIndex,
+    currentText,
+  } = prevState;
+
+  const nextInputs = splice.change(inputTexts, focusIndex, currentText);
+
+  // 하위 terminal input cell은 재평가된다
+  const leadingActives = isActives.slice(0, focusIndex);
+  const followingActives = isActives.slice(focusIndex).map(() => false);
+  const nextActives = leadingActives.concat(followingActives);
+
+  const nextOutputs = splice.change(outputTexts, focusIndex, "");
+
+  // 하위 terminal input cell이 재평가되면 output도 변한다.
+  const leadingLoadings = isLoadings.slice(0, focusIndex);
+  const followingLoadings = isLoadings.slice(focusIndex).map(() => true);
+  const nextLoadings = leadingLoadings.concat(followingLoadings);
+
+  return {
+    inputTexts: nextInputs,
+    isActives: nextActives,
+    outputTexts: nextOutputs,
+    isLoadings: nextLoadings,
+  };
+};
+
+const terminalReducerHandler = {
+  [TERMINAL_ACTION.NEW_REPL]: (state) => {
+    const prevState = deepCopy(state);
+
+    const isLastIndex = prevState.focusIndex >= prevState.replCount;
+    let replCount = null;
+    let nextRepls = null;
+    if (isLastIndex) {
+      replCount = prevState.replCount + 1;
+      nextRepls = appendNewRepl(prevState);
+    } else {
+      replCount = prevState.replCount;
+      nextRepls = updateRepl(prevState);
+    }
+
+    return {
+      focusIndex: replCount,
+      currentText: "",
+
+      ...nextRepls,
+
+      replCount,
+    };
+  },
+
+  // [TERMINAL_ACTION.EVAL_INPUT]: (state, action) => {},
+
+  // [TERMINAL_ACTION.EVAL_ALL]: (state, action) => {},
+
+  [TERMINAL_ACTION.FOCUS_CHANGE]: (state, action) => {
+    const nextState = deepCopy(state);
+    const { to } = action;
+    const { currentText, focusIndex } = nextState;
+
+    const targetIndex = focusIndex + to;
+
+    const nextCurrent = nextState.inputTexts[targetIndex];
+
+    nextState.focusIndex = targetIndex;
+
+    nextState.currentText = nextCurrent;
+
+    nextState.inputTexts = splice.change(
+      nextState.inputTexts,
+      targetIndex,
+      currentText
+    );
+    nextState.isActives = splice.change(
+      nextState.isActives,
+      targetIndex,
+      false
+    );
+
+    nextState.outputTexts = splice.change(
+      nextState.outputTexts,
+      targetIndex,
+      ""
+    );
+    nextState.isLoadings = splice.change(
+      nextState.isLoadings,
+      targetIndex,
+      true
+    );
+
+    nextState.replCount = nextState.inputTexts.length;
+
+    return nextState;
+  },
+
+  [TERMINAL_ACTION.CHANGE_TEXT]: (state, action) => {
+    const nextState = deepCopy(state);
+    nextState.currentText = action.text;
+    return nextState;
+  },
+
+  [TERMINAL_ACTION.UPDATE_OUTPUT]: (state, action) => {
+    const nextState = deepCopy(state);
+    const { index, text } = action;
+
+    nextState.outputTexts = splice.change(nextState.outputTexts, index, text);
+
+    return nextState;
+  },
+};
+
+const terminalReducer = (state, action) => {
+  const handler = terminalReducerHandler[action.type];
+
+  if (handler === undefined) {
+    return state;
+  }
+
+  const nextState = handler(state, action);
+  return nextState;
+};
+
+export default terminalReducer;


### PR DESCRIPTION
![boost-writer-0 2](https://user-images.githubusercontent.com/4661295/69839079-6d397600-1299-11ea-95ee-53fad81c43c6.gif)

위 상황이 지금 master에 있는 결과물입니다.

현재 저희 마크다운 문법 $$$를 입력하면 터미널 뷰가 생성되고 not-pending shell command는 입/출력이 됩니다.

여기서 말하는 not-pending shell command는 ls, echo 처럼 입력을 하면 stdin으로 기다리지않고 바로 결과물을 출력할 수 있는 쉘 명령을 말합니다.

반대로 cat >> hello.txt 같은 경우 사용자의 입력을 기다리게되므로 이런 명령들을 pending shell command라고 하고 지금은 이 기능은 구현되어있지않습니다.

지금 gif에서 하는 동작 중에 키보드 arrow up 키로 이미 작성한 쉘 명령에 포커스를 변경하는 작업이 있습니다.

포커스를 변경하면 다시 값을 평가해야해서 이전에 작성한 내역이 사라집니다.

이 기능은 아직 버그가 있어서 보시는 것처럼 제대로 동작하지않습니다. 
- 포커스도 부분적으로 아직 동작하지않습니다.
- 포커스를 이동한 다음 명령어를 입력하면 잘 동작하지않습니다.

## 질문

터미널 뷰의 랜더링 방식과 포커싱 방식이 괜찮은 방향으로 진행한것인지 질문드리고 싶습니다.

지금 터미널 뷰는 repl cell들과 단 하나의 movable repl cell로 구성되어있습니다.

여기서 말하는 cell은 react component인데 저희가 마크다운 컴포넌트들을 cell로 부르기로해서 이렇게 기술했습니다.

repl cell은 단지 출력하는 용도의 cell이어서 terminal store에 저장되어있는 데이터를 가져와서 출력합니다.

실제로 데이터를 입력받는 부분은 movable repl cell이고, 포커스를 변경한다는 의미는 movable repl cell가 출력되는 위치를 변경한다는 의미입니다.

예를 들어 다음과 같습니다.

store에 데이터가 다음과 같이 구성되어있습니다. (필요한 부분만 간단하게 기술하겠습니다)

```
store =  
  InputTexts: [ repl1, repl2, repl3 ],
  outputTexts: [out1, out2, out3 ],
  focusIndex: 3
  currentText: ""
```

출력은 다음처럼됩니다.

```
===
repl1
out1
===

===
repl2
out2
===

===
repl3
out3
===

// 사용자 입력을 받는 repl. (focus되어 있습니다)
$ ->
```

이 상황에서 사용자가 movable repl cell에 `echo "hello"`을 입력하면 데이터는 다음과 같이 변합니다.

```
store =  
  InputTexts: [ repl1, repl2, repl3 ],
  outputTexts: [out1, out2, out3 ],
  focusIndex: 3
  currentText: "echo "hello""
```

그리고 엔터를 눌러 값을 평가하면 해당 값을 새로운 repl cell로 만들면서 맨 아래로 movable cell이 이동합니다.

즉 다음과 같이 변합니다.

```
store =  
  InputTexts: [ repl1, repl2, repl3, echo "hello" ],
  outputTexts: [out1, out2, out3, "" ],
  focusIndex: 4
  currentText: ""
```

출력(뷰)은 다음처럼 됩니다.


```
===
repl1
out1
===

===
repl2
out2
===

===
repl3
out3
===

===
echo "hello"
""
===

// 사용자 입력을 받는 repl. (focus되어 있습니다)
$ ->
```

`echo "hello"`는 서버 요청을 하기때문에 조금 기다리면 결과물이 출려되고 데이터는 다음처럼 바뀝니다.

```
store =  
  InputTexts: [ repl1, repl2, repl3, echo "hello" ],
  outputTexts: [out1, out2, out3, "hello" ],
  focusIndex: 4
  currentText: ""
```


```
===
repl1
out1
===

===
repl2
out2
===

===
repl3
out3
===

===
echo "hello"
"hello"
===

// 사용자 입력을 받는 repl. (focus되어 있습니다)
$ ->
```

이 상황에서 키보드 arrow up키를 누르면 movable repl cell을 위로 이동시킵니다.

방법은 focusIndex를 변경만하면 movable repl cell이 해당 위치에 출력되도록 변경하는 것입니다.

```
store =  
  InputTexts: [ repl1, repl2, repl3, "" ],
  outputTexts: [out1, out2, out3, "" ],
  focusIndex: 3
  currentText: ""
```


```
===
repl1
out1
===

===
repl2
out2
===

===
repl3
out3
===


// 사용자 입력을 받는 repl. (focus되어 있습니다)
$ -> echo "hello"

===
""
""
===

```

1. 이렇게 movable repl cell을 이동시키는 방식으로 포커스를 조절하는게 react 스러운 방법일까요?

2. 이렇게 랜더링을 하면 문제는 없을까요?

이상입니다.

읽어주셔서 감사합니다!