### PR TITLE
기본, 리스트, 헤딩 셀에서 백스페이스, 엔터 동작 추가 & 리팩토링 & 블록 기능 추가

### DIFF
--- a/client/src/actions/CellAction.js
+++ b/client/src/actions/CellAction.js
@@ -40,12 +40,11 @@ const cellActionCreator = {
    * @param {Cell} createMarkdownCell 새 셀 컴포넌트를 리턴하는 콜백. 인자로 uuid를 넣어야 한다.
    * @param {String} tag 셀의 타입(태그). 생략시 default input 셀이 생성된다.
    */
-  new(createMarkdownCell, tag = CELL_TAG.DEFAULT, start) {
+  new(createMarkdownCell, tag = CELL_TAG.DEFAULT) {
     return {
       type: CELL_ACTION.NEW,
       createMarkdownCell,
       tag,
-      start: start || null,
     };
   },
 

--- a/client/src/actions/CellAction.js
+++ b/client/src/actions/CellAction.js
@@ -17,7 +17,6 @@ const CELL_ACTION = {
   BLOCK: {
     UP: "cell/block/up",
     DOWN: "cell/block/down",
-    EXIT: "cell/block/exit",
   },
   CURSOR: {
     MOVE: "cell/cursor/move",
@@ -153,12 +152,6 @@ const cellActionCreator = {
     return {
       type: CELL_ACTION.BLOCK.DOWN,
       cellUuid,
-    };
-  },
-
-  blockExit() {
-    return {
-      type: CELL_ACTION.BLOCK.EXIT,
     };
   },
 

--- a/client/src/actions/CellAction.js
+++ b/client/src/actions/CellAction.js
@@ -4,6 +4,7 @@ const CELL_ACTION = {
   INIT: "cell/init",
   NEW: "cell/new",
   INPUT: "cell/input",
+  DELETE: "cell/delete",
   TARGET: {
     TRANSFORM: "cell/target/transform",
   },
@@ -58,6 +59,16 @@ const cellActionCreator = {
       type: CELL_ACTION.INPUT,
       cellUuid,
       text,
+    };
+  },
+
+  /**
+   * @param {Uuid} cellUuid 삭제할 셀의 uuid
+   */
+  delete(cellUuid) {
+    return {
+      type: CELL_ACTION.DELETE,
+      cellUuid,
     };
   },
 

--- a/client/src/actions/CellAction.js
+++ b/client/src/actions/CellAction.js
@@ -23,15 +23,15 @@ const cellActionCreator = {
   /**
    * 셀의 데이터를 초기화시킨다.
    * @param {Cell} createMarkdownCell 초기화할 셀을 리턴하는 콜백. 인자로 uuid를 넣어야 한다.
-   * @param {Number} index 초기화할 셀의 index
-   * - 파라미터로 넘기지 않으면 기본값 0
+   * @param {Uuid} cellUuid 초기화할 셀의 uuid
+   * - 파라미터로 넘기지 않으면 기본값 null
    */
-  init(createMarkdownCell, index = 0) {
+  init(createMarkdownCell, cellUuid) {
     return {
       type: CELL_ACTION.INIT,
       createMarkdownCell,
       tag: CELL_TAG.DEFAULT,
-      index,
+      cellUuid: cellUuid || null,
     };
   },
 

--- a/client/src/actions/CellAction.js
+++ b/client/src/actions/CellAction.js
@@ -14,6 +14,11 @@ const CELL_ACTION = {
     MOVE: "cell/focus/move",
     ATTACH: "cell/focus/attach",
   },
+  BLOCK: {
+    UP: "cell/block/up",
+    DOWN: "cell/block/down",
+    EXIT: "cell/block/exit",
+  },
   CURSOR: {
     MOVE: "cell/cursor/move",
   },
@@ -134,6 +139,26 @@ const cellActionCreator = {
       tag,
       cell,
       start: start || null,
+    };
+  },
+
+  blockUp(cellUuid) {
+    return {
+      type: CELL_ACTION.BLOCK.UP,
+      cellUuid,
+    };
+  },
+
+  blockDown(cellUuid) {
+    return {
+      type: CELL_ACTION.BLOCK.DOWN,
+      cellUuid,
+    };
+  },
+
+  blockExit() {
+    return {
+      type: CELL_ACTION.BLOCK.EXIT,
     };
   },
 

--- a/client/src/actions/CellAction.js
+++ b/client/src/actions/CellAction.js
@@ -37,12 +37,15 @@ const cellActionCreator = {
 
   /**
    * 셀을 생성한다.
-   * @param {Cell} createMarkdownCell 새 셀 컴포넌트를 리턴하는 콜백. 인자로 uuid를 넣어야 한다.
+   * @param {Uuid} cellUuid 새 셀을 생성할 기준 셀의 uuid
+   * - 엔터시 기준 셀의 다음 셀에 셀을 생성한다.
+   * @param {Cell} createMarkdownCell 새 셀 컴포넌트를 리턴하는 콜백
    * @param {String} tag 셀의 타입(태그). 생략시 default input 셀이 생성된다.
    */
-  new(createMarkdownCell, tag = CELL_TAG.DEFAULT) {
+  new(cellUuid, createMarkdownCell, tag = CELL_TAG.DEFAULT) {
     return {
       type: CELL_ACTION.NEW,
+      cellUuid,
       createMarkdownCell,
       tag,
     };
@@ -62,6 +65,7 @@ const cellActionCreator = {
   },
 
   /**
+   * 지정한 셀을 삭제한다.
    * @param {Uuid} cellUuid 삭제할 셀의 uuid
    */
   delete(cellUuid) {

--- a/client/src/actions/CellAction.js
+++ b/client/src/actions/CellAction.js
@@ -117,15 +117,15 @@ const cellActionCreator = {
   /**
    * 셀의 속성을 변경한다.
    * - ex) default input cell -> list cell
-   * @param {Number} index 변경할 Cell의 인덱스
+   * @param {Uuid} cellUuid 변경할 Cell의 uuid
    * @param {String} text 변경할 Cell의 텍스트
    * @param {String} tag 변경할 Cell의 태그
    * @param {React.element} cell 변경할 Cell 요소
    */
-  transform(index, text, tag, cell, start) {
+  transform(cellUuid, text, tag, cell, start) {
     return {
       type: CELL_ACTION.TARGET.TRANSFORM,
-      index,
+      cellUuid,
       text,
       tag,
       cell,

--- a/client/src/actions/CellAction.js
+++ b/client/src/actions/CellAction.js
@@ -30,12 +30,12 @@ const cellActionCreator = {
    * @param {Uuid} cellUuid 초기화할 셀의 uuid
    * - 파라미터로 넘기지 않으면 기본값 null
    */
-  init(createMarkdownCell, cellUuid) {
+  init(createMarkdownCell, cellUuid = null) {
     return {
       type: CELL_ACTION.INIT,
       createMarkdownCell,
       tag: CELL_TAG.DEFAULT,
-      cellUuid: cellUuid || null,
+      cellUuid,
     };
   },
 

--- a/client/src/components/editor/cells/Heading/handler.jsx
+++ b/client/src/components/editor/cells/Heading/handler.jsx
@@ -4,4 +4,8 @@ const newCell = (cellDispatch, componentCallback, tag) => {
   cellDispatch(cellActionCreator.new(componentCallback, tag));
 };
 
-export { newCell };
+const initCell = (cellUuid, cellDispatch, componentCallback) => {
+  cellDispatch(cellActionCreator.init(componentCallback, cellUuid));
+};
+
+export { newCell, initCell };

--- a/client/src/components/editor/cells/Heading/handler.jsx
+++ b/client/src/components/editor/cells/Heading/handler.jsx
@@ -1,7 +1,7 @@
 import { cellActionCreator } from "../../../../actions/CellAction";
 
-const newCell = (cellDispatch, componentCallback, tag) => {
-  cellDispatch(cellActionCreator.new(componentCallback, tag));
+const newCell = (cellUuid, cellDispatch, componentCallback, tag) => {
+  cellDispatch(cellActionCreator.new(cellUuid, componentCallback, tag));
 };
 
 const initCell = (cellUuid, cellDispatch, componentCallback) => {

--- a/client/src/components/editor/cells/Heading/index.jsx
+++ b/client/src/components/editor/cells/Heading/index.jsx
@@ -64,7 +64,7 @@ const HeadingCell = ({ cellUuid }) => {
       const componentCallback = cellGenerator.p;
       saveCursorPosition(dispatch, inputRef);
       dispatch(cellActionCreator.input(cellUuid, textContent));
-      newCell(dispatch, componentCallback);
+      newCell(cellUuid, dispatch, componentCallback);
     }
   };
 
@@ -108,6 +108,7 @@ const HeadingCell = ({ cellUuid }) => {
 
   const onClick = () => {
     handlerManager.attachKeydownEvent(window, keydownHandlers, cellIndex, tag);
+    dispatch(cellActionCreator.focusMove(cellUuid));
   };
 
   const htmlText = () => {

--- a/client/src/components/editor/cells/Heading/index.jsx
+++ b/client/src/components/editor/cells/Heading/index.jsx
@@ -13,7 +13,6 @@ import { EVENT_TYPE } from "../../../../enums";
 import { useCellState, handlerManager } from "../../../../utils";
 
 import {
-  newCell,
   saveCursorPosition,
   isContinuePrev,
   isContinueNext,
@@ -22,7 +21,7 @@ import {
   setCursorPosition,
   createCursor,
 } from "../Markdown/handler";
-import MarkdownCell from "../Markdown";
+import { newCell, initCell } from "./handler";
 import { cellGenerator, setGenerator } from "../CellGenerator";
 
 setGenerator("h1", (uuid) => <HeadingCell cellUuid={uuid} />);
@@ -31,8 +30,6 @@ setGenerator("h3", (uuid) => <HeadingCell cellUuid={uuid} />);
 setGenerator("h4", (uuid) => <HeadingCell cellUuid={uuid} />);
 setGenerator("h5", (uuid) => <HeadingCell cellUuid={uuid} />);
 setGenerator("h6", (uuid) => <HeadingCell cellUuid={uuid} />);
-
-// import {  } from "./handler";
 
 // const HeadingCell = React.forwardRef(({ cellUuid }, ref) => {
 const HeadingCell = ({ cellUuid }) => {
@@ -51,12 +48,24 @@ const HeadingCell = ({ cellUuid }) => {
   //   },
   // }));
 
+  const backspaceEvent = (e) => {
+    const { length } = e.target.textContent;
+    if (length === 0) {
+      const componentCallback = cellGenerator.p;
+      initCell(cellUuid, dispatch, componentCallback);
+    }
+  };
+
   const enterEvent = (e) => {
     const { textContent } = e.target;
-    const componentCallback = cellGenerator.p;
-    saveCursorPosition(dispatch, inputRef);
-    dispatch(cellActionCreator.input(cellUuid, textContent));
-    newCell(dispatch, componentCallback);
+    if (textContent.length === 0) {
+      backspaceEvent(e);
+    } else {
+      const componentCallback = cellGenerator.p;
+      saveCursorPosition(dispatch, inputRef);
+      dispatch(cellActionCreator.input(cellUuid, textContent));
+      newCell(dispatch, componentCallback);
+    }
   };
 
   const arrowUpEvent = (e) => {
@@ -75,6 +84,7 @@ const HeadingCell = ({ cellUuid }) => {
     [EVENT_TYPE.ENTER]: enterEvent,
     [EVENT_TYPE.ARROW_UP]: arrowUpEvent,
     [EVENT_TYPE.ARROW_DOWN]: arrowDownEvent,
+    [EVENT_TYPE.BACKSPACE]: backspaceEvent,
   };
 
   if (currentIndex === cellIndex) {

--- a/client/src/components/editor/cells/Heading/index.jsx
+++ b/client/src/components/editor/cells/Heading/index.jsx
@@ -49,8 +49,8 @@ const HeadingCell = ({ cellUuid }) => {
   // }));
 
   const backspaceEvent = (e) => {
-    const { length } = e.target.textContent;
-    if (length === 0) {
+    const { textContent } = e.target;
+    if (textContent.length === 0) {
       const componentCallback = cellGenerator.p;
       initCell(cellUuid, dispatch, componentCallback);
     }

--- a/client/src/components/editor/cells/List/handler.jsx
+++ b/client/src/components/editor/cells/List/handler.jsx
@@ -1,7 +1,11 @@
 import { cellActionCreator } from "../../../../actions/CellAction";
 
-const newCell = (cellDispatch, componentCallback, tag, start) => {
-  cellDispatch(cellActionCreator.new(componentCallback, tag, start));
+const newCell = (cellDispatch, componentCallback, tag) => {
+  cellDispatch(cellActionCreator.new(componentCallback, tag));
 };
 
-export { newCell };
+const initCell = (cellUuid, cellDispatch, componentCallback) => {
+  cellDispatch(cellActionCreator.init(componentCallback, cellUuid));
+};
+
+export { newCell, initCell };

--- a/client/src/components/editor/cells/List/handler.jsx
+++ b/client/src/components/editor/cells/List/handler.jsx
@@ -1,7 +1,7 @@
 import { cellActionCreator } from "../../../../actions/CellAction";
 
-const newCell = (cellDispatch, componentCallback, tag) => {
-  cellDispatch(cellActionCreator.new(componentCallback, tag));
+const newCell = (cellUuid, cellDispatch, componentCallback, tag) => {
+  cellDispatch(cellActionCreator.new(cellUuid, componentCallback, tag));
 };
 
 const initCell = (cellUuid, cellDispatch, componentCallback) => {

--- a/client/src/components/editor/cells/List/index.jsx
+++ b/client/src/components/editor/cells/List/index.jsx
@@ -50,6 +50,14 @@ const ListCell = ({ cellUuid }) => {
   //   },
   // }));
 
+  const backspaceEvent = (e) => {
+    const { length } = e.target.textContent;
+    if (length === 0) {
+      const componentCallback = cellGenerator.p;
+      initCell(cellUuid, dispatch, componentCallback);
+    }
+  };
+
   const enterEvent = (e) => {
     const { textContent } = e.target;
     /*
@@ -66,15 +74,19 @@ const ListCell = ({ cellUuid }) => {
         )
       );
       */
-    const isOrderedList = tag === "ol";
+    if (textContent.length === 0) {
+      backspaceEvent(e);
+    } else {
+      const isOrderedList = tag === "ol";
 
-    const componentCallback = isOrderedList
-      ? cellGenerator.ol
-      : cellGenerator.ul;
+      const componentCallback = isOrderedList
+        ? cellGenerator.ol
+        : cellGenerator.ul;
 
-    saveCursorPosition(dispatch, inputRef);
-    dispatch(cellActionCreator.input(cellUuid, textContent));
-    newCell(dispatch, componentCallback, tag);
+      saveCursorPosition(dispatch, inputRef);
+      dispatch(cellActionCreator.input(cellUuid, textContent));
+      newCell(dispatch, componentCallback, tag);
+    }
   };
 
   const arrowUpEvent = (e) => {
@@ -93,6 +105,7 @@ const ListCell = ({ cellUuid }) => {
     [EVENT_TYPE.ENTER]: enterEvent,
     [EVENT_TYPE.ARROW_UP]: arrowUpEvent,
     [EVENT_TYPE.ARROW_DOWN]: arrowDownEvent,
+    [EVENT_TYPE.BACKSPACE]: backspaceEvent,
   };
 
   if (currentIndex === cellIndex) {

--- a/client/src/components/editor/cells/List/index.jsx
+++ b/client/src/components/editor/cells/List/index.jsx
@@ -85,7 +85,7 @@ const ListCell = ({ cellUuid }) => {
 
       saveCursorPosition(dispatch, inputRef);
       dispatch(cellActionCreator.input(cellUuid, textContent));
-      newCell(dispatch, componentCallback, tag);
+      newCell(cellUuid, dispatch, componentCallback, tag);
     }
   };
 
@@ -129,6 +129,7 @@ const ListCell = ({ cellUuid }) => {
 
   const onClick = () => {
     handlerManager.attachKeydownEvent(window, keydownHandlers, cellIndex, tag);
+    dispatch(cellActionCreator.focusMove(cellUuid));
   };
 
   const htmlText = () => {

--- a/client/src/components/editor/cells/List/index.jsx
+++ b/client/src/components/editor/cells/List/index.jsx
@@ -18,7 +18,7 @@ import {
   setCursorPosition,
   createCursor,
 } from "../Markdown/handler";
-import { newCell } from "./handler";
+import { newCell, initCell } from "./handler";
 import { cellGenerator, setGenerator } from "../CellGenerator";
 
 setGenerator("ul", (uuid) => (
@@ -41,9 +41,6 @@ const ListCell = ({ cellUuid }) => {
     cellUuid
   );
   let inputRef = null;
-
-  const { start } = state;
-  const newStart = start + 1;
 
   // const inputRef = useRef();
 
@@ -69,24 +66,15 @@ const ListCell = ({ cellUuid }) => {
         )
       );
       */
-    const isOrderedList = tag == "ol";
+    const isOrderedList = tag === "ol";
 
-    const component = (uuid) =>
-      isOrderedList ? (
-        <ol start={newStart}>
-          <ListCell cellUuid={uuid} />
-        </ol>
-      ) : (
-        <ul>
-          <ListCell cellUuid={uuid} />
-        </ul>
-      );
-
-    const componentCallback = (uuid) => component(uuid);
+    const componentCallback = isOrderedList
+      ? cellGenerator.ol
+      : cellGenerator.ul;
 
     saveCursorPosition(dispatch, inputRef);
     dispatch(cellActionCreator.input(cellUuid, textContent));
-    newCell(dispatch, componentCallback, tag, newStart);
+    newCell(dispatch, componentCallback, tag);
   };
 
   const arrowUpEvent = (e) => {

--- a/client/src/components/editor/cells/Markdown/handler.jsx
+++ b/client/src/components/editor/cells/Markdown/handler.jsx
@@ -24,11 +24,11 @@ const saveCursorPosition = (cellDispatch, inputRef) => {
   return null;
 };
 
-const newCell = (cellDispatch, componentCallback, tag) => {
+const newCell = (cellUuid, cellDispatch, componentCallback, tag) => {
   if (tag) {
-    cellDispatch(cellActionCreator.new(componentCallback, tag));
+    cellDispatch(cellActionCreator.new(cellUuid, componentCallback, tag));
   } else {
-    cellDispatch(cellActionCreator.new(componentCallback));
+    cellDispatch(cellActionCreator.new(cellUuid, componentCallback));
   }
 };
 

--- a/client/src/components/editor/cells/Markdown/handler.jsx
+++ b/client/src/components/editor/cells/Markdown/handler.jsx
@@ -65,6 +65,14 @@ const focusPrev = (cellUuid, textContent, cellDispatch, inputRef) => {
   cellDispatch(cellActionCreator.focusPrev());
 };
 
+const blockEndUp = (cellUuid, cellDispatch) => {
+  cellDispatch(cellActionCreator.blockUp(cellUuid));
+};
+
+const blockEndDown = (cellUuid, cellDispatch) => {
+  cellDispatch(cellActionCreator.blockDown(cellUuid));
+};
+
 const createCursor = (text, cursor) => {
   const cursorFront = text.slice(0, cursor.start);
   const cursorBack = text.slice(cursor.start, text.length);
@@ -92,6 +100,8 @@ export {
   focusPrev,
   isContinueNext,
   focusNext,
+  blockEndUp,
+  blockEndDown,
   createCursor,
   setCursorPosition,
 };

--- a/client/src/components/editor/cells/Markdown/handler.jsx
+++ b/client/src/components/editor/cells/Markdown/handler.jsx
@@ -32,6 +32,10 @@ const newCell = (cellDispatch, componentCallback, tag) => {
   }
 };
 
+const deleteCell = (cellDispatch, cellUuid) => {
+  cellDispatch(cellActionCreator.delete(cellUuid));
+};
+
 const saveText = (cellUuid, textContent, cellDispatch, inputRef) => {
   saveCursorPosition(cellDispatch, inputRef);
   cellDispatch(cellActionCreator.input(cellUuid, textContent));
@@ -82,6 +86,7 @@ const setCursorPosition = () => {
 
 export {
   newCell,
+  deleteCell,
   saveCursorPosition,
   isContinuePrev,
   focusPrev,

--- a/client/src/components/editor/cells/Markdown/index.jsx
+++ b/client/src/components/editor/cells/Markdown/index.jsx
@@ -93,11 +93,12 @@ const MarkdownCell = ({ cellUuid }) => {
 
       const isOrderedList = matchingTag === "ol";
 
-      const newStart = isOrderedList
-        ? start
-          ? start + 1
-          : getStart(textContent)
-        : 0;
+      let newStart = null;
+      if (isOrderedList) {
+        newStart = start ? start + 1 : getStart(textContent);
+      } else {
+        newStart = 0;
+      }
 
       const cell = makeNewCell(cellUuid, newStart);
 

--- a/client/src/components/editor/cells/Markdown/index.jsx
+++ b/client/src/components/editor/cells/Markdown/index.jsx
@@ -39,7 +39,7 @@ const MarkdownCell = ({ cellUuid }) => {
     const componentCallback = cellGenerator.p;
     saveCursorPosition(dispatch, inputRef);
     dispatch(cellActionCreator.input(cellUuid, textContent));
-    newCell(dispatch, componentCallback);
+    newCell(cellUuid, dispatch, componentCallback);
   };
 
   const arrowUpEvent = (e) => {
@@ -119,6 +119,7 @@ const MarkdownCell = ({ cellUuid }) => {
 
   const onClick = () => {
     handlerManager.attachKeydownEvent(window, keydownHandlers, cellIndex);
+    dispatch(cellActionCreator.focusMove(cellUuid));
   };
 
   const htmlText = () => {

--- a/client/src/components/editor/cells/Markdown/index.jsx
+++ b/client/src/components/editor/cells/Markdown/index.jsx
@@ -17,6 +17,8 @@ import {
   focusNext,
   createCursor,
   setCursorPosition,
+  blockEndUp,
+  blockEndDown,
 } from "./handler";
 
 setGenerator("p", (uuid) => <MarkdownCell cellUuid={uuid} />);
@@ -27,13 +29,14 @@ setGenerator("hr", (uuid) => (
 const MarkdownCell = ({ cellUuid }) => {
   const { state } = useContext(CellContext);
   const dispatch = useContext(CellDispatchContext);
-  const { currentIndex, uuidManager, start, cursor } = state;
+  const { currentIndex, uuidManager, start, cursor, block } = state;
   let inputRef = null;
 
   const cellIndex = uuidManager.findIndex(cellUuid);
   const text = state.texts[cellIndex];
   const currentTag = state.tags[cellIndex];
 
+  // -------------- Handler -----------------------
   const enterEvent = (e) => {
     const { textContent } = e.target;
     const componentCallback = cellGenerator.p;
@@ -48,10 +51,18 @@ const MarkdownCell = ({ cellUuid }) => {
     }
   };
 
+  const shiftArrowUpEvent = () => {
+    blockEndUp(cellUuid, dispatch);
+  };
+
   const arrowDownEvent = (e) => {
     if (isContinueNext(cellIndex, state.cells.length)) {
       focusNext(cellUuid, e.target.textContent, dispatch, inputRef);
     }
+  };
+
+  const shiftArrowDownEvent = () => {
+    blockEndDown(cellUuid, dispatch);
   };
 
   const backspaceEvent = (e) => {
@@ -64,9 +75,13 @@ const MarkdownCell = ({ cellUuid }) => {
   const keydownHandlers = {
     [EVENT_TYPE.ENTER]: enterEvent,
     [EVENT_TYPE.ARROW_UP]: arrowUpEvent,
+    [EVENT_TYPE.SHIFT_ARROW_UP]: shiftArrowUpEvent,
     [EVENT_TYPE.ARROW_DOWN]: arrowDownEvent,
+    [EVENT_TYPE.SHIFT_ARROW_DOWN]: shiftArrowDownEvent,
     [EVENT_TYPE.BACKSPACE]: backspaceEvent,
   };
+
+  // -------------- End -----------------------
 
   if (currentIndex === cellIndex) {
     inputRef = state.inputRef;
@@ -131,9 +146,12 @@ const MarkdownCell = ({ cellUuid }) => {
     return { __html: text };
   };
 
+  const intoShiftBlock = true;
+
   const renderTarget = (
     <MarkdownWrapper
       as={currentTag}
+      intoShiftBlock={intoShiftBlock}
       placeholder={PLACEHOLDER[currentTag]}
       contentEditable
       onKeyUp={onKeyUp}

--- a/client/src/components/editor/cells/Markdown/index.jsx
+++ b/client/src/components/editor/cells/Markdown/index.jsx
@@ -9,6 +9,7 @@ import { CellContext, CellDispatchContext } from "../../../../stores/CellStore";
 import { cellActionCreator } from "../../../../actions/CellAction";
 import {
   newCell,
+  deleteCell,
   saveCursorPosition,
   isContinuePrev,
   focusPrev,
@@ -53,10 +54,18 @@ const MarkdownCell = ({ cellUuid }) => {
     }
   };
 
+  const backspaceEvent = (e) => {
+    const { length } = e.target.textContent;
+    if (length === 0 && cellIndex > 0) {
+      deleteCell(dispatch, cellUuid);
+    }
+  };
+
   const keydownHandlers = {
     [EVENT_TYPE.ENTER]: enterEvent,
     [EVENT_TYPE.ARROW_UP]: arrowUpEvent,
     [EVENT_TYPE.ARROW_DOWN]: arrowDownEvent,
+    [EVENT_TYPE.BACKSPACE]: backspaceEvent,
   };
 
   if (currentIndex === cellIndex) {

--- a/client/src/components/editor/cells/Markdown/index.jsx
+++ b/client/src/components/editor/cells/Markdown/index.jsx
@@ -36,6 +36,16 @@ const MarkdownCell = ({ cellUuid }) => {
   const text = state.texts[cellIndex];
   const currentTag = state.tags[cellIndex];
 
+  let intoShiftBlock = false;
+
+  if (block.start && block.end) {
+    const blockStart = block.start < block.end ? block.start : block.end;
+    const blockEnd = block.start > block.end ? block.start : block.end;
+    if (blockStart <= cellIndex && cellIndex <= blockEnd) {
+      intoShiftBlock = true;
+    }
+  }
+
   // -------------- Handler -----------------------
   const enterEvent = (e) => {
     const { textContent } = e.target;
@@ -145,8 +155,6 @@ const MarkdownCell = ({ cellUuid }) => {
      */
     return { __html: text };
   };
-
-  const intoShiftBlock = true;
 
   const renderTarget = (
     <MarkdownWrapper

--- a/client/src/components/editor/cells/Markdown/index.jsx
+++ b/client/src/components/editor/cells/Markdown/index.jsx
@@ -112,7 +112,7 @@ const MarkdownCell = ({ cellUuid }) => {
       const cell = makeNewCell(cellUuid, newStart);
 
       dispatch(
-        cellActionCreator.transform(cellIndex, "", matchingTag, cell, newStart)
+        cellActionCreator.transform(cellUuid, "", matchingTag, cell, newStart)
       );
     }
   };

--- a/client/src/components/editor/style/MarkdownWrapper.jsx
+++ b/client/src/components/editor/style/MarkdownWrapper.jsx
@@ -21,6 +21,9 @@ const MarkdownWrapper = styled.p`
 
   padding: 0.2em;
 
+  background: ${({ intoShiftBlock }) =>
+    intoShiftBlock && "rgba(128, 0, 255, 0.2)"};
+
   border-left: ${({ isQuote }) => isQuote && "0.25rem solid silver"};
   padding-left: ${({ isQuote }) => isQuote && "0.5rem"};
 `;

--- a/client/src/enums/EVENT_TYPE.js
+++ b/client/src/enums/EVENT_TYPE.js
@@ -5,7 +5,9 @@ const EVENT_TYPE = {
   TAB: "tab",
   SHIFT_TAB: "shift_tab",
   ARROW_UP: "arrow_up",
+  SHIFT_ARROW_UP: "shift_arrow_up",
   ARROW_DOWN: "arrow_down",
+  SHIFT_ARROW_DOWN: "shift_arrow_down",
 };
 
 export default EVENT_TYPE;

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -27,17 +27,20 @@ const cellReducerHandler = {
   },
 
   [CELL_ACTION.NEW]: (state, action) => {
-    const { currentIndex, uuidManager } = state;
-    const { createMarkdownCell, start } = action;
+    const { currentIndex, uuidManager, start } = state;
+    const { createMarkdownCell, tag } = action;
     const cellUuid = uuid();
 
-    const cells = splice.add(
-      state.cells,
-      currentIndex,
-      createMarkdownCell(cellUuid)
-    );
+    const isOrderedList = tag === "ol";
+    const newStart = isOrderedList ? start + 1 : null;
+    const component = isOrderedList
+      ? createMarkdownCell(cellUuid, newStart)
+      : createMarkdownCell(cellUuid);
+
+    const cells = splice.add(state.cells, currentIndex, component);
     const texts = splice.add(state.texts, currentIndex, "");
-    const tags = splice.add(state.tags, currentIndex, action.tag);
+    const tags = splice.add(state.tags, currentIndex, tag);
+
     uuidManager.uuidArray = splice.add(
       uuidManager.uuidArray,
       currentIndex,
@@ -50,7 +53,7 @@ const cellReducerHandler = {
       cells,
       texts,
       tags,
-      start,
+      start: newStart,
     };
   },
 

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -6,17 +6,21 @@ const { splice } = utils;
 
 const cellReducerHandler = {
   [CELL_ACTION.INIT]: (state, action) => {
-    const { index, createMarkdownCell } = action;
+    const { cellUuid, createMarkdownCell, tag } = action;
     const { uuidManager } = state;
-    const cellUuid = uuid();
-    uuidManager.push(cellUuid);
+    const newUuid = cellUuid || uuid();
+    const index = cellUuid ? uuidManager.findIndex(cellUuid) : 0;
+
+    if (!cellUuid) {
+      uuidManager.push(newUuid);
+    }
     const cells = splice.change(
       state.cells,
       index,
-      createMarkdownCell(cellUuid)
+      createMarkdownCell(newUuid)
     );
     const texts = splice.change(state.texts, index, "");
-    const tags = splice.change(state.tags, index, action.tag);
+    const tags = splice.change(state.tags, index, tag);
 
     return {
       ...state,

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -73,10 +73,6 @@ const cellReducerHandler = {
     };
   },
 
-  /**
-   * @todo
-   * new에서 start를 받는데 이건 어떻게 해야하는지 준환님이랑 상의하기
-   */
   [CELL_ACTION.DELETE]: (state, action) => {
     const { uuidManager } = state;
     const { cellUuid } = action;
@@ -134,12 +130,12 @@ const cellReducerHandler = {
   },
 
   [CELL_ACTION.TARGET.TRANSFORM]: (state, action) => {
-    const { index, text, tag, cell, start } = action;
+    const { cellUuid, text, tag, cell, start } = action;
+    const { uuidManager } = state;
+    const index = uuidManager.findIndex(cellUuid);
 
     const texts = splice.change(state.texts, index, text);
-
     const tags = splice.change(state.tags, index, tag);
-
     const cells = splice.change(state.cells, index, cell);
 
     return {

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -162,6 +162,71 @@ const cellReducerHandler = {
     };
   },
 
+  [CELL_ACTION.BLOCK.UP]: (state, action) => {
+    const { uuidManager, block } = state;
+    const { cellUuid } = action;
+    const index = uuidManager.findIndex(cellUuid);
+
+    const newStart = block.start || index;
+    let newEnd = block.end > 0 ? block.end - 1 : newStart;
+    if (block.end > 0) {
+      newEnd = block.end - 1;
+    } else if (block.end === 0) {
+      newEnd = 0;
+    } else {
+      newEnd = newStart;
+    }
+
+    const newBlock = {
+      start: newStart,
+      end: newEnd,
+    };
+
+    return {
+      ...state,
+      block: newBlock,
+    };
+  },
+
+  [CELL_ACTION.BLOCK.DOWN]: (state, action) => {
+    const { uuidManager, block, cells } = state;
+    const { cellUuid } = action;
+    const index = uuidManager.findIndex(cellUuid);
+
+    const { length } = cells;
+
+    const newStart = block.start || index;
+    let newEnd = block.end < length - 1 ? block.end + 1 : newStart;
+    if (block.end < length - 1) {
+      newEnd = block.end + 1;
+    } else if (block.end === length - 1) {
+      newEnd = length - 1;
+    } else {
+      newEnd = newStart;
+    }
+
+    const newBlock = {
+      start: newStart,
+      end: newEnd,
+    };
+
+    return {
+      ...state,
+      block: newBlock,
+    };
+  },
+
+  [CELL_ACTION.BLOCK.EXIT]: (state) => {
+    const block = {
+      start: null,
+      end: null,
+    };
+    return {
+      ...state,
+      block,
+    };
+  },
+
   [CELL_ACTION.CURSOR.MOVE]: (state, action) => {
     const cursor = {
       start: action.selectionStart,

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -31,29 +31,32 @@ const cellReducerHandler = {
   },
 
   [CELL_ACTION.NEW]: (state, action) => {
-    const { currentIndex, uuidManager, start } = state;
-    const { createMarkdownCell, tag } = action;
-    const cellUuid = uuid();
+    const { uuidManager, start } = state;
+    const { cellUuid, createMarkdownCell, tag } = action;
+    const index = uuidManager.findIndex(cellUuid);
+    const newCellUuid = uuid();
 
     const isOrderedList = tag === "ol";
     const newStart = isOrderedList ? start + 1 : null;
     const component = isOrderedList
-      ? createMarkdownCell(cellUuid, newStart)
-      : createMarkdownCell(cellUuid);
+      ? createMarkdownCell(newCellUuid, newStart)
+      : createMarkdownCell(newCellUuid);
 
-    const cells = splice.add(state.cells, currentIndex, component);
-    const texts = splice.add(state.texts, currentIndex, "");
-    const tags = splice.add(state.tags, currentIndex, tag);
+    const cells = splice.add(state.cells, index, component);
+    const texts = splice.add(state.texts, index, "");
+    const tags = splice.add(state.tags, index, tag);
 
     uuidManager.uuidArray = splice.add(
       uuidManager.uuidArray,
-      currentIndex,
-      cellUuid
+      index,
+      newCellUuid
     );
+
+    const currentIndex = index + 1;
 
     return {
       ...state,
-      currentIndex: currentIndex + 1,
+      currentIndex,
       cells,
       texts,
       tags,

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -43,8 +43,19 @@ const cellReducerHandler = {
       : createMarkdownCell(newCellUuid);
 
     const cells = splice.add(state.cells, index, component);
-    const texts = splice.add(state.texts, index, "");
+
+    const originText = state.texts[index];
+    const { cursor } = state;
+    const currentText = originText.slice(0, cursor.start);
+    const newText = originText.slice(cursor.start);
+    let texts = splice.change(state.texts, index, currentText);
+    texts = splice.add(texts, index, newText);
     const tags = splice.add(state.tags, index, tag);
+
+    const newCursor = {
+      start: 0,
+      end: 0,
+    };
 
     uuidManager.uuidArray = splice.add(
       uuidManager.uuidArray,
@@ -60,6 +71,7 @@ const cellReducerHandler = {
       cells,
       texts,
       tags,
+      cursor: newCursor,
       start: newStart,
     };
   },

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -114,16 +114,26 @@ const cellReducerHandler = {
   },
 
   [CELL_ACTION.FOCUS.PREV]: (state) => {
+    const block = {
+      start: null,
+      end: null,
+    };
     return {
       ...state,
       currentIndex: state.currentIndex - 1,
+      block,
     };
   },
 
   [CELL_ACTION.FOCUS.NEXT]: (state) => {
+    const block = {
+      start: null,
+      end: null,
+    };
     return {
       ...state,
       currentIndex: state.currentIndex + 1,
+      block,
     };
   },
 
@@ -197,7 +207,7 @@ const cellReducerHandler = {
 
     const newStart = block.start || index;
     let newEnd = block.end < length - 1 ? block.end + 1 : newStart;
-    if (block.end < length - 1) {
+    if (block.end && block.end < length - 1) {
       newEnd = block.end + 1;
     } else if (block.end === length - 1) {
       newEnd = length - 1;
@@ -213,17 +223,6 @@ const cellReducerHandler = {
     return {
       ...state,
       block: newBlock,
-    };
-  },
-
-  [CELL_ACTION.BLOCK.EXIT]: (state) => {
-    const block = {
-      start: null,
-      end: null,
-    };
-    return {
-      ...state,
-      block,
     };
   },
 

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -66,6 +66,35 @@ const cellReducerHandler = {
     };
   },
 
+  /**
+   * @todo
+   * new에서 start를 받는데 이건 어떻게 해야하는지 준환님이랑 상의하기
+   */
+  [CELL_ACTION.DELETE]: (state, action) => {
+    const { uuidManager } = state;
+    const { cellUuid } = action;
+    const index = uuidManager.findIndex(cellUuid);
+
+    const cells = splice.delete(state.cells, index);
+    const texts = splice.delete(state.texts, index);
+    const tags = splice.delete(state.tags, index);
+    uuidManager.uuidArray = splice.delete(uuidManager.uuidArray, index);
+    const cursor = {
+      start: index - 1 >= 0 ? texts[index - 1].length : 0,
+      end: index - 1 >= 0 ? texts[index - 1].length : 0,
+    };
+    const currentIndex = index - 1;
+
+    return {
+      ...state,
+      cells,
+      texts,
+      tags,
+      currentIndex,
+      cursor,
+    };
+  },
+
   [CELL_ACTION.FOCUS.PREV]: (state) => {
     return {
       ...state,

--- a/client/src/reducers/CellReducer.js
+++ b/client/src/reducers/CellReducer.js
@@ -97,18 +97,18 @@ const cellReducerHandler = {
     const texts = splice.delete(state.texts, index);
     const tags = splice.delete(state.tags, index);
     uuidManager.uuidArray = splice.delete(uuidManager.uuidArray, index);
+    const prevIndex = index - 1;
     const cursor = {
-      start: index - 1 >= 0 ? texts[index - 1].length : 0,
-      end: index - 1 >= 0 ? texts[index - 1].length : 0,
+      start: prevIndex >= 0 ? texts[prevIndex].length : 0,
+      end: prevIndex >= 0 ? texts[prevIndex].length : 0,
     };
-    const currentIndex = index - 1;
 
     return {
       ...state,
       cells,
       texts,
       tags,
-      currentIndex,
+      currentIndex: prevIndex,
       cursor,
     };
   },

--- a/client/src/stores/CellStore.jsx
+++ b/client/src/stores/CellStore.jsx
@@ -18,6 +18,10 @@ const CellStore = ({ children }) => {
       start: 0,
       end: 0,
     },
+    block: {
+      start: null,
+      end: null,
+    },
     start: null,
   });
 

--- a/client/src/utils/Common.js
+++ b/client/src/utils/Common.js
@@ -9,11 +9,7 @@ utils.splice = {
    */
   add: (array, cur, data = null) => {
     if (array.length > 0) {
-      return [
-        ...array.slice(0, cur + 1),
-        data,
-        ...array.slice(cur + 1, array.length),
-      ];
+      return [...array.slice(0, cur + 1), data, ...array.slice(cur + 1)];
     }
     return [data];
   },
@@ -26,7 +22,7 @@ utils.splice = {
    */
   addBefore: (array, cur, data = null) => {
     if (array.length > 0) {
-      return [...array.slice(0, cur), data, ...array.slice(cur, array.length)];
+      return [...array.slice(0, cur), data, ...array.slice(cur)];
     }
     return [data];
   },
@@ -39,11 +35,7 @@ utils.splice = {
    */
   change: (array, cur, data) => {
     if (array.length > 0) {
-      return [
-        ...array.slice(0, cur),
-        data,
-        ...array.slice(cur + 1, array.length),
-      ];
+      return [...array.slice(0, cur), data, ...array.slice(cur + 1)];
     }
     return [data];
   },
@@ -54,7 +46,7 @@ utils.splice = {
    */
   delete: (array, cur) => {
     if (array.length > 0) {
-      return [...array.slice(0, cur), ...array.slice(cur + 1, array.length)];
+      return [...array.slice(0, cur), ...array.slice(cur + 1)];
     }
     return [];
   },

--- a/client/src/utils/Common.js
+++ b/client/src/utils/Common.js
@@ -47,6 +47,17 @@ utils.splice = {
     }
     return [data];
   },
+
+  /**
+   * @param {Array} array 데이터를 삭제할 배열
+   * @param {Number} cur 현재 인덱스
+   */
+  delete: (array, cur) => {
+    if (array.length > 0) {
+      return [...array.slice(0, cur), ...array.slice(cur + 1, array.length)];
+    }
+    return [];
+  },
 };
 
 utils.deepCopy = (obj) => {

--- a/client/src/utils/HandlerManager.js
+++ b/client/src/utils/HandlerManager.js
@@ -81,11 +81,13 @@ const customKeydownEventHandler = (e) => {
         break;
       case "ArrowUp":
         e.preventDefault();
-        handler[EVENT_TYPE.ARROW_UP](e);
+        if (e.shiftKey) handler[EVENT_TYPE.SHIFT_ARROW_UP](e);
+        else handler[EVENT_TYPE.ARROW_UP](e);
         break;
       case "ArrowDown":
         e.preventDefault();
-        handler[EVENT_TYPE.ARROW_DOWN](e);
+        if (e.shiftKey) handler[EVENT_TYPE.SHIFT_ARROW_DOWN](e);
+        else handler[EVENT_TYPE.ARROW_DOWN](e);
         break;
       default:
         break;


### PR DESCRIPTION
### 기본 셀
- 내용이 없을 때 백스페이스 입력시 셀 삭제

### 리스트 셀, 헤딩 셀
- 내용이 없을 때 엔터, 백스페이스를 입력시 기본 마크다운 셀로 초기화

### 리팩토링
- 플럭스 패턴 상에서 index를 인자로 받아오는 액션들을 uuid를 받아와 리듀서에서 index를 검색하도록 변경

### 블록 기능
- 쉬프트 + 위/아래 화살표 입력시 블록 기능 추가
- 실질적인 동작은 하지 않음(css만 입혀짐)
- 추후에 개발할 ctrl+c, v 기능 추가시 사용