### PR TITLE
Refactor: 도커 API 역할을 함수명에 매치

### DIFF
--- a/server/src/api/docker.js
+++ b/server/src/api/docker.js
@@ -206,21 +206,22 @@ class DockerApi {
       name: defaultTagName,
       Tty: true,
     });
-    // TODO startContainer 결과를 합쳐서 리턴 할 것
-    await this.startContainer(newContainerInfo.id);
     return newContainerInfo.id;
   }
 
-  async startContainer(containerId) {
-    const container = await this.request.getContainer(containerId);
+  async startContainer(container) {
     const result = await container.start();
     return result;
   }
 
-  async stopContainer(containerId) {
-    const container = await this.request.getContainer(containerId);
+  async stopContainer(container) {
     const result = await container.stop();
     return result;
+  }
+
+  async getContainer(containerId) {
+    const container = await this.request.getContainer(containerId);
+    return container;
   }
 }
 

--- a/server/src/controller/terminal.js
+++ b/server/src/controller/terminal.js
@@ -3,16 +3,20 @@ const createDefaultTerminal = async (
   baseImageName = "ubuntu"
 ) => {
   const containerId = await dockerInstance.createDefaultTerminal(baseImageName);
-  return containerId;
+  const container = await dockerInstance.getContainer(containerId);
+  const result = await dockerInstance.startContainer(container);
+  return result;
 };
 
 const startTerminal = async (dockerInstance, containerId) => {
-  const result = await dockerInstance.startContainer(containerId);
+  const container = await dockerInstance.getContainer(containerId);
+  const result = await dockerInstance.startContainer(container);
   return result;
 };
 
 const stopTerminal = async (dockerInstance, containerId) => {
-  const result = await dockerInstance.stopContainer(containerId);
+  const container = await dockerInstance.getContainer(containerId);
+  const result = await dockerInstance.stopContainer(container);
   return result;
 };
 


### PR DESCRIPTION
- 도커 API에 있는 함수중에 2개의 역할을 하는 함수를 분리
- 컨트롤러에서 분리한 함수들을 차례 대로 실행