### PR TITLE
[김윤환]w5_리뷰요청_키보드 이벤트

### DIFF
--- a/client/src/components/editor/cells/Terminal/ReplContainer.jsx
+++ b/client/src/components/editor/cells/Terminal/ReplContainer.jsx
@@ -1,0 +1,137 @@
+import React, { useContext, useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import createDebug from "debug";
+
+import { EVENT_TYPE } from "../../../../enums";
+import { utils, useKeys } from "../../../../utils";
+import { cellActionCreator as cellAction } from "../../../../actions/CellAction";
+import { CellDispatchContext } from "../../../../stores/CellStore";
+import { terminalActionCreator as terminalAction } from "../../../../actions/TerminalAction";
+import {
+  TerminalContext,
+  TerminalDispatchContext,
+} from "../../../../stores/TerminalStore";
+import MovableReplCell from "./MovableReplCell";
+import ReplCell from "./ReplCell";
+
+const { splice } = utils;
+
+const debug = createDebug("boost:component:repl-container");
+
+const renderReplList = (cellIndex, terminalState) => {
+  const {
+    inputTexts,
+    stdinTexts,
+    outputTexts,
+
+    isActives,
+    isLoadings,
+  } = terminalState;
+
+  const replList = inputTexts.map((_, index) => {
+    const componentKey = `${cellIndex}/repl/${index}`;
+    return (
+      <ReplCell
+        key={componentKey}
+        cellIndex={index}
+        inputText={inputTexts[index]}
+        stdinText={stdinTexts[index]}
+        outputText={outputTexts[index]}
+        isActive={isActives[index]}
+        isLoading={isLoadings[index]}
+      />
+    );
+  });
+
+  return replList;
+};
+
+const ReplContainer = ({ cellUuid, cellIndex, isCellFocus }) => {
+  const [movable, setMovable] = useState(null);
+  const [isReplFocus, setIsReplFocus] = useState(true);
+  const dispatchToTerminal = useContext(TerminalDispatchContext);
+  const dispatchToCell = useContext(CellDispatchContext);
+  const { terminalState } = useContext(TerminalContext);
+  const { focusIndex, currentText, currentStdin, replCount } = terminalState;
+
+  const focusHandlers = {
+    [EVENT_TYPE.ENTER]: (e) => {
+      e.preventDefault();
+      if (isReplFocus) {
+        setIsReplFocus(false);
+      } else {
+        setIsReplFocus(true);
+        dispatchToTerminal(terminalAction.createNewRepl(replCount));
+      }
+    },
+
+    [EVENT_TYPE.BACKSPACE]: (e) => {
+      const { textContent } = e.target;
+      if (textContent.length === 0) {
+        if (replCount === 0) {
+          dispatchToCell(cellAction.delete(cellUuid));
+        } else {
+          dispatchToTerminal(terminalAction.deleteRepl());
+        }
+      }
+    },
+
+    [EVENT_TYPE.ARROW_UP]: (e) => {
+      e.preventDefault();
+      const isFocusTop = focusIndex === 0;
+      if (isFocusTop) {
+        debug("Focus in top");
+        dispatchToTerminal(terminalAction.focusOut());
+        dispatchToCell(cellAction.focusPrev());
+      } else {
+        debug("Focus prev", focusIndex);
+        dispatchToTerminal(terminalAction.focusPrev());
+      }
+    },
+
+    [EVENT_TYPE.ARROW_DOWN]: (e) => {
+      e.preventDefault();
+      if (focusIndex === replCount) {
+        debug("Focus Down Max");
+      } else if (focusIndex >= 0 && focusIndex < replCount) {
+        debug("Focus Down In Terminal");
+        dispatchToTerminal(terminalAction.focusNext());
+      }
+    },
+  };
+
+  useKeys(focusHandlers, isCellFocus, [focusIndex, isReplFocus]);
+
+  useEffect(() => {
+    if (isCellFocus) {
+      setMovable(
+        <MovableReplCell
+          key="movable-repl-cell"
+          currentText={currentText}
+          currentStdin={currentStdin}
+          isReplFocus={isReplFocus}
+        />
+      );
+    }
+  }, [focusIndex, isReplFocus]);
+
+  const isFirstRender = movable && replCount === 0;
+  if (isFirstRender) {
+    return <>{movable}</>;
+  }
+
+  const replList = renderReplList(cellIndex, terminalState);
+  if (!isCellFocus) {
+    return <>{replList}</>;
+  }
+
+  const replsWithMovable = splice.addBefore(replList, focusIndex, movable);
+  return <>{replsWithMovable}</>;
+};
+
+ReplContainer.propTypes = {
+  cellIndex: PropTypes.number.isRequired,
+  isCellFocus: PropTypes.bool.isRequired,
+};
+
+export default ReplContainer;

--- a/client/src/utils/HandlerManager.js
+++ b/client/src/utils/HandlerManager.js
@@ -1,0 +1,207 @@
+import { useEffect } from "react";
+import { EVENT_TYPE } from "../enums";
+
+const KEY_TYPE = {
+  ENTER: "Enter",
+  TAB: "Tab",
+  BACKSPACE: "Backspace",
+  ARROW_UP: "ArrowUp",
+  ARROW_DOWN: "ArrowDown",
+};
+
+const checkOsDependentCtrl = (e) => {
+  const { ctrlKey, metaKey } = e;
+  const agentInfo = navigator.userAgent.toLowerCase();
+  const isMac = agentInfo.includes("mac");
+  if (isMac) {
+    return metaKey;
+  }
+
+  const isWindowOrLinux =
+    agentInfo.includes("linux") || agentInfo.includes("window");
+  if (isWindowOrLinux) {
+    return ctrlKey;
+  }
+
+  // any other minor os
+  return ctrlKey;
+};
+
+const makeKeyHandler = {
+  [EVENT_TYPE.ENTER]: (handler) => {
+    return (e) => {
+      const { key, shiftKey } = e;
+      const isEnter = key === KEY_TYPE.ENTER;
+      const isShift = shiftKey;
+      if (isEnter && !isShift) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.SHIFT_ENTER]: (handler) => {
+    return (e) => {
+      const { key, shiftKey } = e;
+      const isShiftEnter = key === KEY_TYPE.ENTER && shiftKey;
+      if (isShiftEnter) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.BACKSPACE]: (handler) => {
+    return (e) => {
+      if (e.key === KEY_TYPE.BACKSPACE) {
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.TAB]: (handler) => {
+    return (e) => {
+      const { key, shiftKey } = e;
+      const isTab = key === KEY_TYPE.TAB;
+      const isShift = shiftKey;
+      if (isTab && !isShift) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.SHIFT_TAB]: (handler) => {
+    return (e) => {
+      const { key, shiftKey } = e;
+      const isShiftTab = key === KEY_TYPE.TAB && shiftKey;
+      if (isShiftTab) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.ARROW_UP]: (handler) => {
+    return (e) => {
+      const { key, shiftKey } = e;
+      const isArrowUp = key === KEY_TYPE.ARROW_UP;
+      const isShiftUp = shiftKey;
+      if (!isShiftUp && isArrowUp) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.SHIFT_ARROW_UP]: (handler) => {
+    return (e) => {
+      const { key, shiftKey } = e;
+      const isShiftUp = key === KEY_TYPE.ARROW_UP && shiftKey;
+      if (isShiftUp) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.ARROW_DOWN]: (handler) => {
+    return (e) => {
+      const { key, shiftKey } = e;
+      const isArrowDown = key === KEY_TYPE.ARROW_DOWN;
+      const isShiftUp = shiftKey;
+      if (!isShiftUp && isArrowDown) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.SHIFT_ARROW_DOWN]: (handler) => {
+    return (e) => {
+      const { key, shiftKey } = e;
+      const isShiftDown = key === KEY_TYPE.ARROW_DOWN && shiftKey;
+      if (isShiftDown) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.CTRL_A]: (handler) => {
+    return (e) => {
+      const isCtrl = checkOsDependentCtrl(e);
+      const isCharA = e.key === "a";
+      if (isCtrl && isCharA) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.CTRL_X]: (handler) => {
+    return (e) => {
+      const isCtrl = checkOsDependentCtrl(e);
+      const isCharX = e.key === "x";
+      if (isCtrl && isCharX) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.CTRL_C]: (handler) => {
+    return (e) => {
+      const isCtrl = checkOsDependentCtrl(e);
+      const isCharC = e.key === "c";
+      if (isCtrl && isCharC) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+
+  [EVENT_TYPE.CTRL_V]: (handler) => {
+    return (e) => {
+      const isCtrl = checkOsDependentCtrl(e);
+      const isCharV = e.key === "v";
+      if (isCtrl && isCharV) {
+        e.preventDefault();
+        handler(e);
+      }
+    };
+  },
+};
+
+const useKey = (keyEvent, handler, isFocus, deps = []) => {
+  const keydownHandler = makeKeyHandler[keyEvent](handler);
+  useEffect(() => {
+    if (isFocus) {
+      window.addEventListener("keydown", keydownHandler);
+    }
+    return () => {
+      window.removeEventListener("keydown", keydownHandler);
+    };
+  }, [isFocus, ...deps]);
+};
+
+const useKeys = (handlers, isFocus, deps = []) => {
+  const keydownHandlers = Object.entries(handlers).map(([type, handler]) => {
+    return makeKeyHandler[type](handler);
+  });
+
+  useEffect(() => {
+    if (isFocus) {
+      keydownHandlers.forEach((handler) => {
+        window.addEventListener("keydown", handler);
+      });
+    }
+    return () => {
+      keydownHandlers.forEach((handler) => {
+        window.removeEventListener("keydown", handler);
+      });
+    };
+  }, [isFocus, ...deps]);
+};
+
+export { useKey, useKeys };


### PR DESCRIPTION
### 상황

마크다운 셀들은 각자의 키보드 이벤트를 다루는 함수들을 가지고 있습니다.

아래 이미지를 살펴보면 기본 셀, 리스트 셀, 터미널 셀에 대해서 다음과 같은 이벤트 동작들이 있습니다.

![boost-writer-0 3](https://user-images.githubusercontent.com/4661295/70290935-f3673680-181c-11ea-921b-febf00cb575d.gif)

기본 셀은 enter 이벤트에 대해서 다음 줄에 새로운 기본 셀을 생성합니다.

리스트 셀은 enter 이벤트에 대해서 현재 포커스된 리스트 셀에 입력값이 있을때와 없을때 동작이 다릅니다.

- 입력값이 있는 경우, 이 다음 줄에 포커스된 리스트와 깊이가 같은 새로운 리스트 셀을 생성합니다.
- 입력값이 없는 경우, 현재 포커스된 리스트 셀을 삭제합니다.

터미널 셀은 안에 들어있는 박스 하나하나를 repl 셀이라고 부르고, enter 이벤트는 이 repl들을 대상으로 다루게됩니다.

터미널 셀에서 enter 이벤트가 발생하면 터미널 셀의 맨 아래쪽에 새로운 repl 셀이 생깁니다.

이 밖에도 각 셀들은 자신들이 처리해야하는 고유의 이벤트가 존재하기때문에 포커스된 셀이 변할때마다 이벤트를 다루는 함수들을 변경시켜주어야합니다.

그래서 **포커스된 셀이 무엇인지** 파악한뒤에 이벤트를 교체하는 작업을 해주는 모듈이 존재하고, 이는 react custom hook으로 만들어서 관리하고 있습니다.

### 질문

react custom hook으로 만들어서 키보드 이벤트를 관리하고 있는데, 이는 포커스된 셀이 변경될때마다 키보드 이벤트를 교체합니다.

이때 키보드 이벤트는 window객체에 이벤트를 추가하고 삭제하는 과정으로 관리를 해야해서 현업에서 window  관련 이벤트를 다룰때 어떻게 하는지 참고할 부분이 있다면 알고싶습니다. 

