### PR TITLE
[박다정]w5_리뷰요청_도커 이미지 생성

### DIFF
--- a/server/src/api/docker.js
+++ b/server/src/api/docker.js
@@ -1,0 +1,215 @@
+const debug = require("debug")("boostwriter:api:Docker");
+const fs = require("fs");
+const Docker = require("dockerode");
+
+const SIGNAL_TYPE = {
+  SIGINT: 2,
+  SIGKILL: 9,
+};
+
+const changeToFormattedName = (name) => {
+  const startFormat = "/";
+  if (name.startsWith(startFormat)) {
+    return name;
+  }
+  return `${startFormat}${name}`;
+};
+
+const exec = async (container, commandString = "", options = {}) => {
+  if (!container) {
+    return null;
+  }
+
+  const defaultOptions = {
+    AttachStdin: true,
+    AttachStdout: true,
+    AttachStderr: true,
+    Cmd: ["/bin/sh", "-c", commandString],
+  };
+
+  const command = await container.exec({ ...defaultOptions, ...options });
+
+  const commandOptions = {
+    hijack: false,
+    stdin: false,
+  };
+
+  if (options.isPending) {
+    commandOptions.hijack = true;
+    // commandOptions.stdin = true;
+  }
+
+  const containerStream = await command.start(commandOptions);
+  return containerStream;
+};
+
+class DockerApi {
+  constructor(options) {
+    const defaultOptions = {
+      version: "v1.40",
+      caPath: "ca.pem",
+      certPath: "cert.pem",
+      keyPath: "key.pem",
+      socketPath: null,
+    };
+    const requestOptions = {
+      ...defaultOptions,
+      ...options,
+    };
+
+    if (requestOptions.caPath) {
+      requestOptions.ca = fs.readFileSync(requestOptions.caPath);
+    }
+
+    if (requestOptions.certPath) {
+      requestOptions.cert = fs.readFileSync(requestOptions.certPath);
+    }
+
+    if (requestOptions.keyPath) {
+      requestOptions.key = fs.readFileSync(requestOptions.keyPath);
+    }
+
+    debug(`Docker Api create request with`, requestOptions);
+
+    this.request = new Docker(requestOptions);
+  }
+
+  async init() {
+    const infos = await this.request.listContainers();
+    this.containerInfos = infos.map((info) => {
+      const keys = Object.keys(info);
+      const lowerCasedObject = {};
+      keys.forEach((key) => {
+        lowerCasedObject[key.toLowerCase()] = info[key];
+      });
+      return lowerCasedObject;
+    });
+  }
+
+  async execById(containerId, commandString = "") {
+    // const isCached = this.isContainerExist(containerId);
+
+    // TODO cache 처리 추가할 것
+
+    const container = await this.request.getContainer(containerId);
+
+    const containerStream = await exec(container, commandString);
+    return containerStream;
+  }
+
+  async execByName(containerName, commandString = "") {
+    const containerId = this.convertToContainerId(containerName);
+
+    const container = await this.request.getContainer(containerId);
+
+    const containerStream = await exec(container, commandString);
+
+    return containerStream;
+  }
+
+  async sendSignal(containerId, signalNumber = SIGNAL_TYPE.SIGINT) {
+    const isCached = this.isContainerExist(containerId);
+
+    if (!isCached) {
+      return null;
+    }
+
+    const container = await this.request.getContainer(containerId);
+
+    const result = await container.kill({
+      id: containerId,
+      signal: signalNumber,
+    });
+    return result;
+  }
+
+  async execPendingById(containerId, commandString = "") {
+    const isCached = this.isContainerExist(containerId);
+
+    if (!isCached) {
+      return null;
+    }
+
+    const container = await this.request.getContainer(containerId);
+
+    const containerStream = await exec(container, commandString, {
+      isPending: true,
+    });
+
+    return containerStream;
+  }
+
+  convertToContainerId(containerName = "") {
+    const formattedName = changeToFormattedName(containerName);
+
+    const isUsedName = (info) => {
+      return info.names.includes(formattedName);
+    };
+
+    const targetInfo = this.containerInfos.find(isUsedName);
+
+    return targetInfo ? targetInfo.id : null;
+  }
+
+  isContainerExist(containerId) {
+    return this.containerInfos.some((info) => {
+      // support compressed-hash and full-hash
+      return info.id.startsWith(containerId);
+    });
+  }
+
+  async createCustomTerminal(dockerFilePath = __dirname) {
+    const imageTagName = "nicenice";
+    // TODO 유저 입력 파싱
+    const defaultOptions = {
+      context: dockerFilePath,
+      src: ["Dockerfile"],
+    };
+
+    const imageTag = {
+      t: imageTagName,
+    };
+
+    const stream = await this.request.buildImage(defaultOptions, imageTag);
+    await new Promise((resolve, reject) => {
+      this.request.modem.followProgress(stream, (err, res) => {
+        return err ? reject(err) : resolve(res);
+      });
+    });
+    const result = await this.createDefaultTerminal(imageTagName);
+    return result;
+    // TODO: refactor
+  }
+
+  async createDefaultTerminal(baseImageName) {
+    // TOOD 초기 하드코딩 값 변경하거나 없앨 것
+    const defaultCmd = ["/bin/bash"];
+    const defaultTagName = baseImageName;
+    const newContainerInfo = await this.request.createContainer({
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Image: baseImageName,
+      Cmd: defaultCmd,
+      name: defaultTagName,
+      Tty: true,
+    });
+    // TODO startContainer 결과를 합쳐서 리턴 할 것
+    await this.startContainer(newContainerInfo.id);
+    return newContainerInfo.id;
+  }
+
+  async startContainer(containerId) {
+    const container = await this.request.getContainer(containerId);
+    const result = await container.start();
+    return result;
+  }
+
+  async stopContainer(containerId) {
+    const container = await this.request.getContainer(containerId);
+    const result = await container.stop();
+    return result;
+  }
+}
+
+module.exports = { DockerApi, SIGNAL_TYPE };

--- a/server/src/api/makeDockerfile.js
+++ b/server/src/api/makeDockerfile.js
@@ -1,0 +1,31 @@
+const path = require("path");
+const fs = require("fs").promises;
+
+// 같은 이름의 파일은 덮어 씀
+const writeDockerfile = async (text) => {
+  const data = new Uint8Array(Buffer.from(text));
+  console.log(process.env.INIT_CWD);
+  await fs.writeFile(`${process.env.INIT_CWD}/dockerfiles/Dockerfile`, data);
+};
+
+const makeDockerfile = async (text) => {
+  await fs.open(
+    // TODO 하드 코딩 경로 수정 할 것
+    `${process.env.INIT_CWD}/dockerfiles/Dockerfile`,
+    "wx",
+    async (err, fd) => {
+      if (err) {
+        if (err.code === "EEXIST") {
+          console.error("myfile already exists");
+          return;
+        }
+        throw err;
+      }
+      const result = await writeDockerfile(text);
+      console.log(result);
+      return result;
+    }
+  );
+};
+
+module.exports = { writeDockerfile };

--- a/server/src/controller/terminal.js
+++ b/server/src/controller/terminal.js
@@ -1,0 +1,32 @@
+const { writeDockerfile } = require("../api/makeDockerfile");
+
+const createDefaultTerminal = async (
+  dockerInstance,
+  baseImageName = ["ubuntu"]
+) => {
+  const dockerFilePath = `${process.env.INIT_CWD}/dockerfiles/`;
+  // TODO 사용자 도커 환경 정보 파싱(도커파일 규격에 맞는 형식으로)
+  const dockerfile = baseImageName.reduce((accumulate, element) => {
+    return `${accumulate} FROM ${element}\n`;
+  }, "");
+  await writeDockerfile(dockerfile);
+
+  const containerId = await dockerInstance.createCustomTerminal(dockerFilePath);
+  return containerId;
+};
+
+const startTerminal = async (dockerInstance, containerId) => {
+  const result = await dockerInstance.startContainer(containerId);
+  return result;
+};
+
+const stopTerminal = async (dockerInstance, containerId) => {
+  const result = await dockerInstance.stopContainer(containerId);
+  return result;
+};
+
+module.exports = {
+  createDefaultTerminal,
+  startTerminal,
+  stopTerminal,
+};

--- a/server/src/routes/terminal.js
+++ b/server/src/routes/terminal.js
@@ -1,0 +1,90 @@
+const debug = require("debug")("boostwriter:routes:terminal");
+const express = require("express");
+const { StreamResolver } = require("../utils/stream-resolver");
+const { utils } = require("../utils");
+
+const { wrapAsync } = utils;
+
+const router = express.Router();
+
+const {
+  createDefaultTerminal,
+  startTerminal,
+  stopTerminal,
+} = require("../controller/terminal");
+
+const deleteDockerPrefix = (rawString) => {
+  return rawString.slice(8);
+};
+
+const deleteLineFeeding = (rawString) => {
+  if (rawString[rawString.length - 1] === "\n") {
+    return rawString.slice(0, -1);
+  }
+  return rawString;
+};
+
+const resolveDockerStream = async (stream) => {
+  const resolver = new StreamResolver(stream);
+  let rawString = await resolver.flush();
+  rawString = deleteDockerPrefix(rawString);
+  rawString = deleteLineFeeding(rawString);
+  return rawString;
+};
+
+router.post(
+  "/command/not-pending",
+  wrapAsync(async (req, res) => {
+    const { containerName, cmd, options } = req.body;
+    const dockerClient = req.app.get("docker");
+
+    const resultStream = await dockerClient.execByName(containerName, cmd);
+    const output = await resolveDockerStream(resultStream);
+
+    debug(
+      `containerName: ${containerName}`,
+      `command: ${cmd}`,
+      `options: ${options}`,
+      `result: ${output}`
+    );
+
+    res.status(200).send({ output });
+  })
+);
+
+router
+  .route("/")
+  .post(
+    wrapAsync(async (req, res) => {
+      const { dockerData } = req.body;
+      const docker = req.app.get("docker");
+      const result = await createDefaultTerminal(docker, dockerData);
+
+      if (!result) {
+        res.status(400).json({ message: "not created terminal" });
+        return;
+      }
+      console.log(result);
+      res.status(201).json({ containerId: result });
+    })
+  )
+  .patch(
+    wrapAsync(async (req, res) => {
+      const docker = req.app.get("docker");
+      const { containerId } = req.body;
+      const result = await startTerminal(docker, containerId);
+
+      res.status(200).json(result);
+    })
+  )
+  .delete(
+    wrapAsync(async (req, res) => {
+      const docker = req.app.get("docker");
+      const { containerId } = req.body;
+      const result = await stopTerminal(docker, containerId);
+
+      res.status(200).json(result);
+    })
+  );
+
+module.exports = router;


### PR DESCRIPTION
**요구 상황**
사용자의 요청에 맞는 이미지를 빌드 하고 컨테이너를 생성 후 컨테이너 아이디를 response해야 하는 상황
 
**현재 상황**
[서버 흐름도](https://docs.google.com/presentation/d/1srP6WXoJ576zPpHJOrIL7GNFuxPQLzmmdOutRMwmzGY/edit?usp=sharing)
이런 흐름에서 도커파일을 api서버가 생성하고 있습니다.

**알고 싶은 것**
1.도커이미지 빌드 시간을 단축하고 싶어서 생각한 방안이 적절한지 알고 싶습니다.

1-1.선택지를 제한해서 필요한 도커서버에서 이미지를 전부 받아 놓는다.

1-2.현재 단순하게 구현한 상황이라 dockerfile을 아래와 같이 변경합니다.
변경 전
```
FROM node 
FROM python                                                 
```

변경 후
```
FROM ubuntu
RUN apt-get update && apt-get install node~~
```
이런 이유는 도커가 로컬에 이미지가 없으면 원격으로 이미지를 받아오기 때문입니다.

2. dockerfile 이외에 코드상으로 어떻게 하면 더 빠르게 할 수 있을지 궁금합니다.