### PR TITLE
서버에 socket io 모듈 및 ssh 모듈 지원

### DIFF
--- a/server/bin/index.js
+++ b/server/bin/index.js
@@ -7,8 +7,7 @@
 require("../src/env-loader").appendEnv("remote");
 
 const debug = require("debug")("boostwriter:index");
-const http = require("http");
-const app = require("../src/app");
+const { app, server } = require("../src/app");
 
 /**
  * Get port from environment and store in Express.
@@ -17,11 +16,6 @@ const app = require("../src/app");
 const port = process.env.EXPRESS_PORT || 3000;
 app.set("port", port);
 
-/**
- * Create HTTP server.
- */
-
-const server = http.createServer(app);
 /**
  * Event listener for HTTP server "error" event.
  */

--- a/server/package.json
+++ b/server/package.json
@@ -8,16 +8,20 @@
     "lint": "nps lint.code"
   },
   "dependencies": {
+    "connect-redis": "^4.0.3",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dockerode": "^3.0.2",
     "dotenv": "^8.2.0",
     "express": "~4.16.1",
+    "express-session": "^1.17.0",
     "http-errors": "~1.6.3",
     "morgan": "~1.9.1",
     "mysql2": "^2.0.0",
-    "node-ssh": "^6.0.0"
+    "redis": "^2.8.0",
+    "socket.io": "^2.3.0",
+    "ssh2": "^0.8.7"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/server/src/api/ssh.js
+++ b/server/src/api/ssh.js
@@ -1,0 +1,98 @@
+const debug = require("debug")("boost:api:ssh");
+const Ssh = require("ssh2");
+
+const SIGNAL = {
+  SIGINT: "\x03",
+};
+
+const isSignal = (str) => {
+  return Object.keys(SIGNAL).includes(str);
+};
+
+class SshConnection {
+  constructor() {
+    this.connection = new Ssh();
+    this.channel = null;
+    this.resolvedOptions = {};
+  }
+
+  async connect(options) {
+    const defaultOptions = {
+      tryKeyboard: true,
+      keepaliveInterval: 100 * 1000,
+      keepaliveCountMax: 100,
+    };
+
+    this.resolvedOptions = { ...defaultOptions, ...options };
+
+    this.resolvedOptions.onKeyboardInteractive = (
+      name,
+      instructions,
+      instructionsLang,
+      prompts,
+      finish
+    ) => {
+      finish([this.resolvedOptions.password]);
+    };
+
+    const makeConnection = () => {
+      return new Promise((resolve, reject) => {
+        this.connection.on("ready", () => {
+          debug(`ssh connection ready!`);
+
+          const channel = this.makeShellChannel();
+
+          resolve(channel);
+        });
+
+        this.connection.on("error", (err) => {
+          debug(`ssh connection error : ${err}`);
+
+          reject(err);
+        });
+
+        this.connection.connect(this.resolvedOptions);
+      });
+    };
+
+    this.channel = await makeConnection();
+    return this.channel;
+  }
+
+  async makeShellChannel() {
+    const makeShell = () => {
+      return new Promise((resolve, reject) => {
+        this.connection.shell((err, channel) => {
+          if (err) {
+            debug("Fail to create shell", err);
+            reject(err);
+          } else {
+            resolve(channel);
+          }
+        });
+      });
+    };
+
+    const channel = await makeShell();
+    return channel;
+  }
+
+  write(str) {
+    const trimmed = str.trim();
+    if (isSignal(trimmed)) {
+      const signalStr = SIGNAL[trimmed];
+
+      debug(`Send signal ${trimmed} : ${signalStr}`);
+
+      this.channel.write(signalStr);
+    } else {
+      const line = trimmed.endsWith("\n") ? trimmed : `${trimmed}\n`;
+
+      debug(`Send shell command ${line}`);
+
+      this.channel.write(line);
+    }
+  }
+}
+
+export default SshConnection;

--- a/server/src/utils/index.js
+++ b/server/src/utils/index.js
@@ -1,4 +1,6 @@
 const { StreamResolver } = require("./stream-resolver");
+const socketManager = require("./socket-manager");
+const sshManager = require("./ssh-manager");
 
 const utils = {};
 
@@ -16,4 +18,4 @@ utils.isFunction = (v) => {
   return typeof v === "function";
 };
 
-module.exports = { utils, StreamResolver };
+module.exports = { utils, StreamResolver, socketManager, sshManager };

--- a/server/src/utils/socket-manager.js
+++ b/server/src/utils/socket-manager.js
@@ -1,0 +1,47 @@
+const debug = require("debug")("boostwriter:socket-manager");
+
+class SocketManager {
+  constructor() {
+    this.server = null;
+    this.connections = {};
+  }
+
+  init(server) {
+    this.server = server;
+  }
+
+  async makeClientConnection(session) {
+    const { id } = session;
+    if (this.connections[id] !== undefined) {
+      this.disconnectSocket(id);
+    }
+    this.connections[id] = {
+      io: this.server.of(`/io/${id}`),
+      socket: null,
+    };
+
+    const current = this.connections[id];
+    const currentIo = current.io;
+
+    return new Promise((resolve) => {
+      currentIo.on("connection", (socket) => {
+        debug(`Connection success with ${id}`);
+        current.socket = socket;
+        resolve(socket);
+      });
+    });
+  }
+
+  attachEvent(id, event, cb) {
+    const { socket } = this.connections[id];
+    socket.on(event, cb);
+  }
+
+  disconnectSocket(id) {
+    const targetSocket = this.connections[id].socket;
+    targetSocket.disconnect(true);
+    this.connections[id].socket = null;
+  }
+}
+
+module.exports = new SocketManager();

--- a/server/src/utils/ssh-manager.js
+++ b/server/src/utils/ssh-manager.js
@@ -1,0 +1,21 @@
+const SshConnection = require("../api/ssh");
+
+class SshConnectionManager {
+  constructor() {
+    this.connections = {};
+  }
+
+  async makeShellConnection(session) {
+    const { id } = session;
+    this.connections[id] = new SshConnection();
+    const current = this.connections[id];
+    const shellChannel = await current.connect({ ...session });
+    return shellChannel;
+  }
+
+  getConnection(id) {
+    return this.connections[id];
+  }
+}
+
+export default new SshConnectionManager();


### PR DESCRIPTION
- ssh 모듈을 통해서 docker container와 통신하도록 지원
- socket io 모듈을 통해서 프론트의 terminal cell과 통신하도록 지원
- socket io 모듈이 후에 사용할 express의 세션기능과 잘 융합시키기위한 기반 미들웨어 마련
- socket io 모듈이 connection을 관리하도록 manager 모듈 제공