### PR TITLE
terminal 삭제시 outputTexts가 안사라지는 버그 해결

### DIFF
--- a/client/src/components/editor/cells/Terminal/ReplContainer.jsx
+++ b/client/src/components/editor/cells/Terminal/ReplContainer.jsx
@@ -42,6 +42,7 @@ const ReplContainer = ({ cellUuid, cellIndex, isCellFocus }) => {
     [EVENT_TYPE.SHIFT_BACKSPACE]: () => {
       debug("Shift backspace terminal cell");
       dispatchToCell(cellAction.init(null, cellUuid));
+      dispatchToCell(cellAction.input(cellUuid, ""));
     },
 
     [EVENT_TYPE.OPTION_COMMAND_DOWN]: () => {

--- a/client/src/utils/SocketManager.js
+++ b/client/src/utils/SocketManager.js
@@ -14,7 +14,7 @@ class SocketManager {
 
   enroll(uuid) {
     if (!this.connections[uuid]) {
-      this.connections[uuid] = clientIo(`${process.env.SERVER_URL}/${uuid}`);
+      this.connections[uuid] = clientIo(`${process.env.SERVER_URL}/io/${uuid}`);
       debug("make socket io connection & enroll", uuid, this);
     }
     const connection = this.connections[uuid];


### PR DESCRIPTION
terminal 삭제할때 cell action에 init을 사용하는데, 이 init이라는 아이는
텍스트까지 초기화시켜주지는 않았다. 그래서 input을 다시한번
갱신시켜야 증상을 해결할 수 있었다.