### PR TITLE
[박다정]w6_리뷰요청_컨테이너 사용량 확인

### DIFF
--- a/server/src/api/docker.js
+++ b/server/src/api/docker.js
@@ -1,0 +1,275 @@
+const debug = require("debug")("boostwriter:api:Docker");
+const fs = require("fs");
+const Docker = require("dockerode");
+const uuid = require("uuid/v4");
+
+const SIGNAL_TYPE = {
+  SIGINT: 2,
+  SIGKILL: 9,
+};
+
+const changeToFormattedName = (name) => {
+  const startFormat = "/";
+  if (name.startsWith(startFormat)) {
+    return name;
+  }
+  return `${startFormat}${name}`;
+};
+
+const exec = async (container, commandString = "", options = {}) => {
+  if (!container) {
+    return null;
+  }
+
+  const defaultOptions = {
+    AttachStdin: true,
+    AttachStdout: true,
+    AttachStderr: true,
+    Cmd: ["/bin/sh", "-c", commandString],
+  };
+
+  const command = await container.exec({ ...defaultOptions, ...options });
+
+  const commandOptions = {
+    hijack: false,
+    stdin: false,
+  };
+
+  if (options.isPending) {
+    commandOptions.hijack = true;
+    // commandOptions.stdin = true;
+  }
+
+  const containerStream = await command.start(commandOptions);
+  return containerStream;
+};
+
+class DockerApi {
+  constructor(options) {
+    const defaultOptions = {
+      version: "v1.40",
+      caPath: "ca.pem",
+      certPath: "cert.pem",
+      keyPath: "key.pem",
+      socketPath: null,
+    };
+    const requestOptions = {
+      ...defaultOptions,
+      ...options,
+    };
+
+    if (requestOptions.caPath) {
+      requestOptions.ca = fs.readFileSync(requestOptions.caPath);
+    }
+
+    if (requestOptions.certPath) {
+      requestOptions.cert = fs.readFileSync(requestOptions.certPath);
+    }
+
+    if (requestOptions.keyPath) {
+      requestOptions.key = fs.readFileSync(requestOptions.keyPath);
+    }
+
+    debug(`Docker Api create request with`, requestOptions);
+
+    this.request = new Docker(requestOptions);
+  }
+
+  async init() {
+    const infos = await this.request.listContainers();
+    this.containerInfos = infos.map((info) => {
+      const keys = Object.keys(info);
+      const lowerCasedObject = {};
+      keys.forEach((key) => {
+        lowerCasedObject[key.toLowerCase()] = info[key];
+      });
+      return lowerCasedObject;
+    });
+  }
+
+  async execById(containerId, commandString = "") {
+    // const isCached = this.isContainerExist(containerId);
+
+    // TODO cache 처리 추가할 것
+
+    const container = await this.request.getContainer(containerId);
+
+    const containerStream = await exec(container, commandString);
+    return containerStream;
+  }
+
+  async execByName(containerName, commandString = "") {
+    const containerId = this.convertToContainerId(containerName);
+
+    const container = await this.request.getContainer(containerId);
+
+    const containerStream = await exec(container, commandString);
+
+    return containerStream;
+  }
+
+  async sendSignal(containerId, signalNumber = SIGNAL_TYPE.SIGINT) {
+    const isCached = this.isContainerExist(containerId);
+
+    if (!isCached) {
+      return null;
+    }
+
+    const container = await this.request.getContainer(containerId);
+
+    const result = await container.kill({
+      id: containerId,
+      signal: signalNumber,
+    });
+    return result;
+  }
+
+  async execPendingById(containerId, commandString = "") {
+    const isCached = this.isContainerExist(containerId);
+
+    if (!isCached) {
+      return null;
+    }
+
+    const container = await this.request.getContainer(containerId);
+
+    const containerStream = await exec(container, commandString, {
+      isPending: true,
+    });
+
+    return containerStream;
+  }
+
+  convertToContainerId(containerName = "") {
+    const formattedName = changeToFormattedName(containerName);
+
+    const isUsedName = (info) => {
+      return info.names.includes(formattedName);
+    };
+
+    const targetInfo = this.containerInfos.find(isUsedName);
+
+    return targetInfo ? targetInfo.id : null;
+  }
+
+  isContainerExist(containerId) {
+    return this.containerInfos.some((info) => {
+      // support compressed-hash and full-hash
+      return info.id.startsWith(containerId);
+    });
+  }
+
+  async createCustomTerminal(dockerFilePath) {
+    const imageTagName = uuid();
+    // TODO 유저 입력 파싱
+    const defaultOptions = {
+      context: dockerFilePath,
+      src: ["Dockerfile"],
+    };
+
+    const imageTag = {
+      t: imageTagName,
+    };
+
+    try {
+      const stream = await this.request.buildImage(defaultOptions, imageTag);
+      await this.followProgressAsync(stream);
+      debug("next to follow progress");
+      const result = await this.createDefaultTerminal(imageTagName);
+      return result;
+    } catch (err) {
+      debug("createCustomTerminal error", err);
+      return err;
+    }
+    // TODO: refactor
+  }
+
+  followProgressAsync(stream) {
+    return new Promise((resolve, reject) => {
+      const onProgress = (data) => {
+        debug("following progress", data);
+        console.log("following progress", data);
+      };
+
+      const onFinish = async (err, data) => {
+        if (err) {
+          console.log("progress finish err", err, data);
+          return reject(err);
+        }
+        debug("finish follow progressing", data);
+        console.log("finish follow progressing", data);
+        resolve(data);
+      };
+      this.request.modem.followProgress(stream, onFinish, onProgress);
+    });
+  }
+
+  async createDefaultTerminal(baseImageName) {
+    // TOOD 초기 하드코딩 값 변경하거나 없앨 것
+    const defaultCmd = ["/bin/bash"];
+    const defaultTagName = baseImageName;
+    const newContainerInfo = await this.request.createContainer({
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Image: baseImageName,
+      Cmd: defaultCmd,
+      name: defaultTagName,
+      Tty: true,
+    });
+    // TODO startContainer 결과를 합쳐서 리턴 할 것
+    await this.startContainer(newContainerInfo.id);
+    return newContainerInfo.id;
+  }
+
+  async startContainer(containerId) {
+    const container = await this.request.getContainer(containerId);
+    const result = await container.start();
+    return result;
+  }
+
+  async stopContainer(containerId) {
+    const container = await this.request.getContainer(containerId);
+    const result = await container.stop();
+    return result;
+  }
+
+  async saveContainer(containerId) {
+    const container = await this.request.getContainer(containerId);
+    const result = await container.commit(containerId);
+    return result;
+  }
+
+  async monitorContainer(containerId) {
+    const container = await this.request.getContainer(containerId);
+
+    let timerId = null;
+
+    const setIntervalHandler = async () => {
+      let totalNetworksUsage = 0;
+
+      const userMetric = await container.stats({
+        id: containerId,
+        stream: false,
+      });
+
+      if (!userMetric || !userMetric.networks) {
+        return false;
+      }
+      Object.keys(userMetric.networks).forEach(async (element) => {
+        totalNetworksUsage += userMetric.networks[element].rx_bytes;
+        totalNetworksUsage += userMetric.networks[element].tx_bytes;
+      });
+
+      if (totalNetworksUsage > 100000) {
+        await container.stop();
+        clearInterval(timerId);
+      }
+    };
+    timerId = setInterval(setIntervalHandler, 1000);
+
+    return true;
+  }
+}
+
+module.exports = { DockerApi, SIGNAL_TYPE };


### PR DESCRIPTION
**작성한 내용**
사용자의 터미널 네트워크 사용량을 확인하여 일정 수치이상이 넘어가면 정지하는 함수 구현

**현재 상황**
시간이 부족해서 단순하게 express app이 실행되면 setinterval로 현재 실행중인
docker container를 불러오고 하나씩 사용량을 확인하는 이벤트를 등록합니다.

**알고 싶은 것**
컨테이너의 상태를 계속 불러오는 것은 너무 비효율적으로 생각합니다. 그래서 도커파일로 이미지를 만들때
네트워크 사용량을 고정시키는 방법을 개인적으로 알아보고 있는데 만약 이 방법을 사용한다고 하면
사용자가 사용 도중 네트워크 사용량을 늘리는 것을 요청하는 상황이 생긴다면 이미지를 다시 빌드 해야하는데 모든 요청마다 이미지를 다시 빌드하는 것도 아닌것 같고 이미지를 미리 빌드할 수도 없어서 어떤 해결책이
있는지 궁금합니다. 아니면 현재 상태로 계속 실시간으로 컨테이너의 사용량을 받아오는게 맞는걸까요