### PR TITLE
[김윤환]w6_리뷰요청_socket.io와 ssh 연결

### DIFF
--- a/server/src/api/ssh.js
+++ b/server/src/api/ssh.js
@@ -1,0 +1,112 @@
+const debug = require("debug")("boost:api:ssh");
+const Ssh = require("ssh2");
+
+const SIGNAL = {
+  SIGINT: "\x03",
+};
+
+const isSignal = (str) => {
+  return Object.keys(SIGNAL).includes(str);
+};
+
+class SshConnection {
+  constructor() {
+    this.connection = new Ssh();
+    this.channel = null;
+    this.resolvedOptions = {};
+  }
+
+  async connect(options) {
+    const defaultOptions = {
+      tryKeyboard: true,
+      keepaliveInterval: 100 * 1000,
+      keepaliveCountMax: 100,
+    };
+
+    this.resolvedOptions = { ...defaultOptions, ...options };
+
+    // this.resolvedOptions.onKeyboardInteractive = (
+    //  name,
+    //  instructions,
+    //  instructionsLang,
+    //  prompts,
+    //  finish
+    // ) => {
+    //  finish([this.resolvedOptions.password]);
+    // };
+
+    this.connection.on(
+      "keyboard-interactive",
+      (name, instructions, lang, prompts, finish) => {
+        finish([this.resolvedOptions.password]);
+      }
+    );
+
+    const makeConnection = () => {
+      return new Promise((resolve, reject) => {
+        this.connection.on("ready", () => {
+          debug(`ssh connection ready!`);
+
+          const channel = this.makeShellChannel();
+
+          resolve(channel);
+        });
+
+        this.connection.on("error", (err) => {
+          debug(`ssh connection error : ${err}`);
+
+          reject(err);
+        });
+
+        debug(`ssh connection start`, this.connection, this.resolvedOptions);
+        this.connection.connect(this.resolvedOptions);
+      });
+    };
+
+    this.channel = await makeConnection();
+    return this.channel;
+  }
+
+  disconnect() {
+    if (!this.channel) {
+      return false;
+    }
+    this.channel.end();
+    return true;
+  }
+
+  async makeShellChannel() {
+    const makeShell = () => {
+      return new Promise((resolve, reject) => {
+        this.connection.shell((err, channel) => {
+          if (err) {
+            debug("Fail to create shell", err);
+            reject(err);
+          } else {
+            resolve(channel);
+          }
+        });
+      });
+    };
+
+    const channel = await makeShell();
+    return channel;
+  }
+
+  sendSignal(signal) {
+    const trimmed = signal.trim();
+    debug(`Send signal ${trimmed}`);
+    this.channel.write(trimmed);
+  }
+
+  write(str) {
+    const trimmed = str.trim();
+    const line = trimmed.endsWith("\n") ? trimmed : `${trimmed}\n`;
+
+    debug(`Send shell command ${line}`);
+
+    this.channel.write(line);
+  }
+}
+
+module.exports = SshConnection;

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -1,0 +1,103 @@
+const express = require("express");
+const SocketServer = require("socket.io");
+
+const { DockerApi } = require("../src/api/docker");
+const { socketManager, sshManager } = require("../src/utils");
+
+const app = express();
+const server = http.createServer(app);
+const io = new SocketServer(server);
+socketManager.init(io);
+
+/**
+ * Docker를 사용하기 위한 설정
+ */
+const dockerOptions = {
+  host: process.env.REMOTE_DOCKER_IP,
+  port: process.env.REMOTE_DOCKER_PORT,
+  caPath: process.env.SSL_CA_PATH,
+  certPath: process.env.SSL_CERT_PATH,
+  keyPath: process.env.SSL_KEY_PATH,
+};
+
+const docker = new DockerApi(dockerOptions);
+docker.init();
+
+app.set("docker", docker);
+
+/**
+ * 임시로 고정된 ssh 유저 세션을 위한 설정
+ */
+const sshOptions = {
+  id: "testid",
+  username: process.env.REMOTE_SSH_USERNAME,
+  password: process.env.REMOTE_SSH_PASSWORD,
+  port: process.env.REMOTE_CONTAINER_PORT,
+  host: process.env.REMOTE_DOCKER_IP,
+};
+app.set("session", sshOptions);
+
+const sessionMiddleware = (req, res, next) => {
+  // TODO: 후에 express session을 통해서 session객체를 얻어 올 수 있다.
+  req.session = sshOptions;
+  next();
+};
+
+io.use((socket, next) => {
+  sessionMiddleware(socket.request, socket.request.res, next);
+});
+
+app.use(sessionMiddleware);
+
+io.of((name, query, next) => {
+  next(null, true);
+}).on("connection", async (socket) => {
+  const { session } = socket.request;
+  const connectionId = session.id + socket.nsp.name;
+
+  debug("start connecting session", session);
+
+  const shellChannel = await sshManager.makeShellConnection(
+    connectionId,
+    session
+  );
+
+  socketManager.enrollSocket(connectionId, socket);
+
+  debug("Connect socket and shell channel");
+
+  // server <-- docker container
+  shellChannel.on("data", (data) => {
+    debug(`Shell command output : ${data}`);
+    // client <-- server
+    socket.emit("stdout", data);
+  });
+
+  // client --> (server) --> docker container
+  socket.on("stdin", (cmd) => {
+    debug(`Shell command stdin : ${cmd}`);
+    sshManager.writeTo(connectionId, cmd);
+  });
+
+  socket.on("signal", (signal) => {
+    debug(`Shell signal : ${signal}`);
+    sshManager.sendSignal(connectionId, signal);
+  });
+
+  socket.on("disconnect", (reason) => {
+    debug(`socket io disconnect by ${reason}`);
+    sshManager.disconnect(connectionId);
+  });
+
+  shellChannel.on("end", () => {
+    debug("Shell channel connection end");
+  });
+
+  shellChannel.on("close", () => {
+    debug("Shell channel connection close");
+  });
+
+  shellChannel.on("error", (error) => {
+    debug("Shell channel connection error", error);
+  });
+});

--- a/server/src/utils/socket-manager.js
+++ b/server/src/utils/socket-manager.js
@@ -1,0 +1,35 @@
+const debug = require("debug")("boostwriter:socket-manager");
+
+class SocketManager {
+  constructor() {
+    this.server = null;
+    this.connections = {};
+  }
+
+  init(server) {
+    this.server = server;
+  }
+
+  enrollSocket(id, socket) {
+    if (this.connections[id] && this.connections[id].socket) {
+      this.disconnectSocket(id);
+    }
+    this.connections[id] = {};
+    this.connections[id].socket = socket;
+  }
+
+  attachEvent(id, event, cb) {
+    const { socket } = this.connections[id];
+    socket.on(event, cb);
+  }
+
+  disconnectSocket(id) {
+    const targetSocket = this.connections[id].socket;
+    if (targetSocket) {
+      targetSocket.disconnect(true);
+    }
+    this.connections[id].socket = null;
+  }
+}
+
+module.exports = new SocketManager();

--- a/server/src/utils/ssh-manager.js
+++ b/server/src/utils/ssh-manager.js
@@ -1,0 +1,59 @@
+const debug = require("debug")("boostwriter:ssh-manager");
+const SshConnection = require("../api/ssh");
+
+class SshConnectionManager {
+  constructor() {
+    this.connections = {};
+  }
+
+  async makeShellConnection(id, session) {
+    if (this.connections[id]) {
+      return this.connections[id].channel;
+    }
+    this.connections[id] = new SshConnection();
+
+    debug("shell conecting...", this.connections[id]);
+    const current = this.connections[id];
+    let shellChannel;
+    try {
+      shellChannel = await current.connect({ ...session });
+    } catch (err) {
+      debug("shell conection error", err);
+    }
+    return shellChannel;
+  }
+
+  getConnection(id) {
+    return this.connections[id];
+  }
+
+  disconnect(id) {
+    const connection = this.connections[id];
+    if (!connection) {
+      return false;
+    }
+    connection.disconnect();
+    this.connections[id] = null;
+    return true;
+  }
+
+  writeTo(id, cmd) {
+    const connection = this.connections[id];
+    if (!connection) {
+      return false;
+    }
+    connection.write(cmd);
+    return true;
+  }
+
+  sendSignal(id, signal) {
+    const connection = this.connections[id];
+    if (!connection) {
+      return false;
+    }
+    connection.sendSignal(signal);
+    return true;
+  }
+}
+
+module.exports = new SshConnectionManager();


### PR DESCRIPTION
## 상황

```
client terminal <--(socket.io)--> server(express) <--(ssh)--> docker container
```
client에 terminal은 server사이에 통신은 socket io를 통해서 수행하고 있습니다.

server와 docker container사이에 통신은 ssh를 통해 수행하고 있습니다.

client의 terminal은 docker container의 ssh 세션에 데이터를 주고 받을 수 있어야 합니다.

그렇기에 server 측에서 ssh channel과 socket간에 데이터를 알맞게 중계해줘야합니다.

문제는 각 유저의 개개인의 터미널마다 socket 및 ssh channel을 연결해주어야한다는 점입니다.

유저는 여러개의 터미널을 만들 수 있고, 그렇기때문에 socket 연결을 여러개를 만들어서 관리해야합니다.

socket io에서 namespace를 지정해주는 기능이 있는데 이를 통해서 여러개의 socket을 만들고 관리하고 있습니다. 

## 질문

1. socket.io의 namespace를 사용해서 각 터미널 셀과 ssh 통신을 만들어주는 channel로 사용하는 방법이 괜찮을까요? (후에 세션을 추가하여 마구잡이로 연결을 허락하지않도록 할 예정입니다.)

```
// 아래 코드에서 이 부분입니다.
// 지금은 모든 namespace에 대해서 socket을 연결할 수 있도록 하였습니다. 
io.of((name, query, next) => {
  next(null, true);
}).on("connection", async (socket) => {
...
```